### PR TITLE
Frontend refactor

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -6,6 +6,8 @@ qt_add_executable(millennium_serpent
     requestsbox.cpp
     messagesbox.cpp
     codebox.cpp
+    clientsocket.cpp
+    database.cpp
 )
 target_link_libraries(millennium_serpent PRIVATE 
     Qt6::Widgets 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -4,6 +4,7 @@ qt_add_executable(millennium_serpent
     login.cpp
     friendsbox.cpp
     requestsbox.cpp
+    messagesbox.cpp
 )
 target_link_libraries(millennium_serpent PRIVATE 
     Qt6::Widgets 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -5,6 +5,7 @@ qt_add_executable(millennium_serpent
     friendsbox.cpp
     requestsbox.cpp
     messagesbox.cpp
+    codebox.cpp
 )
 target_link_libraries(millennium_serpent PRIVATE 
     Qt6::Widgets 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -3,6 +3,7 @@ qt_add_executable(millennium_serpent
     mainwindow.cpp
     login.cpp
     friendsbox.cpp
+    requestsbox.cpp
 )
 target_link_libraries(millennium_serpent PRIVATE 
     Qt6::Widgets 

--- a/src/app/clientsocket.cpp
+++ b/src/app/clientsocket.cpp
@@ -1,0 +1,182 @@
+#include "clientsocket.h"
+#include <QTcpSocket>
+#include <QTimer>
+#include <QDebug>
+
+ClientSocketManager::ClientSocketManager(QString server_address, QObject *parent)
+    : QObject(parent)
+    , sock(new QTcpSocket(this))
+{
+    // Connect socket signals
+    connect(sock, &QTcpSocket::connected, this, [this]() {
+        qDebug() << "Connected to server";
+    });
+    
+    connect(sock, &QTcpSocket::disconnected, this, [this]() {
+        qDebug() << "Disconnected from server";
+    });
+    
+    connect(sock, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError error) {
+        qDebug() << "Socket error:" << error;
+    });
+    
+    // Connect readyRead to handle incoming data
+    connect(sock, &QTcpSocket::readyRead, this, [this]() {
+        while (sock->bytesAvailable() >= PACKET_BUFFER_SIZE) {
+            char buffer[PACKET_BUFFER_SIZE];
+            qint64 bytesRead = sock->read(buffer, PACKET_BUFFER_SIZE);
+            if (bytesRead == PACKET_BUFFER_SIZE) {
+                handlePacket(buffer);
+            }
+        }
+    });
+    
+    sock->connectToHost(server_address, 1999);
+}
+
+ClientSocketManager::~ClientSocketManager()
+{
+    if (sock->state() == QAbstractSocket::ConnectedState) {
+        sock->disconnectFromHost();
+    }
+}
+
+// Slots for sending packets to server
+void ClientSocketManager::sendAccountRequest(QString user_name, QString password)
+{
+    if (sock->state() != QAbstractSocket::ConnectedState) {
+        qDebug() << "Not connected to server";
+        return;
+    }
+    
+    createAccountRequest packet(user_name.toStdString(), password.toStdString());
+    unsigned char buffer[PACKET_BUFFER_SIZE];
+    int bytesWritten = packet.write_to_packet(buffer);
+    
+    if (bytesWritten > 0) {
+        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
+    }
+}
+
+void ClientSocketManager::sendLoginRequest(QString user_name, QString password)
+{
+    if (sock->state() != QAbstractSocket::ConnectedState) {
+        qDebug() << "Not connected to server";
+        return;
+    }
+    
+    loginRequest packet(user_name.toStdString(), password.toStdString());
+    unsigned char buffer[PACKET_BUFFER_SIZE];
+    int bytesWritten = packet.write_to_packet(buffer);
+    
+    if (bytesWritten > 0) {
+        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
+    }
+}
+
+void ClientSocketManager::sendFriendRequest(QString friend_name)
+{
+    if (sock->state() != QAbstractSocket::ConnectedState) {
+        qDebug() << "Not connected to server";
+        return;
+    }
+    
+    friendRequestSend packet(friend_name.toStdString());
+    unsigned char buffer[PACKET_BUFFER_SIZE];
+    int bytesWritten = packet.write_to_packet(buffer);
+    
+    if (bytesWritten > 0) {
+        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
+    }
+}
+
+void ClientSocketManager::sendFriendRequestResponse(QString friend_name, FriendRequestResponse response)
+{
+    if (sock->state() != QAbstractSocket::ConnectedState) {
+        qDebug() << "Not connected to server";
+        return;
+    }
+    
+    // Note: This needs the 'to' and 'from' parameters from the packet.h
+    // For now, using empty strings - you may need to modify this based on your needs
+    friendRequestAcknowledge packet("", friend_name.toStdString(), response);
+    unsigned char buffer[PACKET_BUFFER_SIZE];
+    int bytesWritten = packet.write_to_packet(buffer);
+    
+    if (bytesWritten > 0) {
+        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
+    }
+}
+
+void ClientSocketManager::sendMessage(QString friend_name, QString message)
+{
+    if (sock->state() != QAbstractSocket::ConnectedState) {
+        qDebug() << "Not connected to server";
+        return;
+    }
+    
+    messageSend packet(message.toStdString(), friend_name.toStdString());
+    unsigned char buffer[PACKET_BUFFER_SIZE];
+    int bytesWritten = packet.write_to_packet(buffer);
+    
+    if (bytesWritten > 0) {
+        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
+    }
+}
+
+// Private method to handle incoming packets and emit signals
+void ClientSocketManager::handlePacket(char *packet)
+{
+    // First byte contains the packet type
+    PacketFromServerType packetType = static_cast<PacketFromServerType>(packet[0]);
+    
+    switch (packetType) {
+        case ACCOUNT_RESULT: {
+            createAccountResponse response(reinterpret_cast<unsigned char*>(packet));
+            emit mentionAccountResult(response.success, QString::fromStdString(response.reason));
+            break;
+        }
+        
+        case LOGIN_RESULT: {
+            loginResult response(reinterpret_cast<unsigned char*>(packet));
+            emit mentionLoginResult(response.success, QString::fromStdString(response.reason));
+            break;
+        }
+        
+        case FRIEND_STATUS_UPDATE: {
+            friendStatusUpdate response(reinterpret_cast<unsigned char*>(packet));
+            emit mentionFriendStatus(QString::fromStdString(response.username), response.status);
+            break;
+        }
+        
+        case FRIEND_REQUEST_FORWARD: {
+            friendRequestForward response(reinterpret_cast<unsigned char*>(packet));
+            emit mentionFriendRequest(QString::fromStdString(response.from));
+            break;
+        }
+        
+        case FRIEND_REQUEST_RESPONSE: {
+            friendRequestResponse response(reinterpret_cast<unsigned char*>(packet));
+            emit mentionFriendRequestResponse(QString::fromStdString(response.from), response.response);
+            break;
+        }
+        
+        case MESSAGE_FORWARD: {
+            messageForward response(reinterpret_cast<unsigned char*>(packet));
+            emit mentionMessage(QString::fromStdString(response.sender), QString::fromStdString(response.message));
+            break;
+        }
+        
+        case MESSAGE_RESPONSE: {
+            messageResponse response(reinterpret_cast<unsigned char*>(packet));
+            // Note: This packet doesn't have a corresponding signal in the header
+            // You may want to add a signal for message delivery confirmation
+            qDebug() << "Message response received, sent:" << response.sent;
+            break;
+        }
+        
+        default:
+            qDebug() << "Unknown packet type received:" << packetType;
+            break;
+    }
+}

--- a/src/app/clientsocket.cpp
+++ b/src/app/clientsocket.cpp
@@ -23,7 +23,8 @@ ClientSocketManager::ClientSocketManager(QString server_address, QObject *parent
     // Connect readyRead to handle incoming data
     connect(sock, &QTcpSocket::readyRead, this, [this]() {
         while (sock->bytesAvailable() >= PACKET_BUFFER_SIZE) {
-            char buffer[PACKET_BUFFER_SIZE];
+            char buffer[PACKET_BUFFER_SIZE + 1];
+            buffer[PACKET_BUFFER_SIZE] = 0;
             qint64 bytesRead = sock->read(buffer, PACKET_BUFFER_SIZE);
             if (bytesRead == PACKET_BUFFER_SIZE) {
                 handlePacket(buffer);
@@ -51,11 +52,9 @@ void ClientSocketManager::sendAccountRequest(QString user_name, QString password
     
     createAccountRequest packet(user_name.toStdString(), password.toStdString());
     unsigned char buffer[PACKET_BUFFER_SIZE];
-    int bytesWritten = packet.write_to_packet(buffer);
+    packet.write_to_packet(buffer);
     
-    if (bytesWritten > 0) {
-        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
-    }
+    sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
 }
 
 void ClientSocketManager::sendLoginRequest(QString user_name, QString password)
@@ -67,11 +66,9 @@ void ClientSocketManager::sendLoginRequest(QString user_name, QString password)
     
     loginRequest packet(user_name.toStdString(), password.toStdString());
     unsigned char buffer[PACKET_BUFFER_SIZE];
-    int bytesWritten = packet.write_to_packet(buffer);
+    packet.write_to_packet(buffer);
     
-    if (bytesWritten > 0) {
-        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
-    }
+    sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
 }
 
 void ClientSocketManager::sendFriendRequest(QString friend_name)
@@ -83,11 +80,8 @@ void ClientSocketManager::sendFriendRequest(QString friend_name)
     
     friendRequestSend packet(friend_name.toStdString());
     unsigned char buffer[PACKET_BUFFER_SIZE];
-    int bytesWritten = packet.write_to_packet(buffer);
-    
-    if (bytesWritten > 0) {
-        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
-    }
+    packet.write_to_packet(buffer);
+    sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
 }
 
 void ClientSocketManager::sendFriendRequestResponse(QString friend_name, FriendRequestResponse response)
@@ -101,11 +95,8 @@ void ClientSocketManager::sendFriendRequestResponse(QString friend_name, FriendR
     // For now, using empty strings - you may need to modify this based on your needs
     friendRequestAcknowledge packet("", friend_name.toStdString(), response);
     unsigned char buffer[PACKET_BUFFER_SIZE];
-    int bytesWritten = packet.write_to_packet(buffer);
-    
-    if (bytesWritten > 0) {
-        sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
-    }
+    packet.write_to_packet(buffer);
+    sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
 }
 
 void ClientSocketManager::sendMessage(QString friend_name, QString message)

--- a/src/app/clientsocket.cpp
+++ b/src/app/clientsocket.cpp
@@ -133,13 +133,15 @@ void ClientSocketManager::handlePacket(char *packet)
     switch (packetType) {
         case ACCOUNT_RESULT: {
             createAccountResponse response(reinterpret_cast<unsigned char*>(packet));
-            emit mentionAccountResult(response.success, QString::fromStdString(response.reason));
+            if (response.success) emit mentionLoginSuccess();
+            else emit mentionAccountResult(QString::fromStdString(response.reason));
             break;
         }
         
         case LOGIN_RESULT: {
             loginResult response(reinterpret_cast<unsigned char*>(packet));
-            emit mentionLoginResult(response.success, QString::fromStdString(response.reason));
+            if (response.success) emit mentionLoginSuccess();
+            else emit mentionLoginResult(QString::fromStdString(response.reason));
             break;
         }
         

--- a/src/app/clientsocket.cpp
+++ b/src/app/clientsocket.cpp
@@ -136,21 +136,18 @@ void ClientSocketManager::handlePacket(char *packet)
         
         case FRIEND_STATUS_UPDATE: {
             friendStatusUpdate response(reinterpret_cast<unsigned char*>(packet));
-            qDebug() << "Received a status update packet stating that " << response.username << " is " << response.status;
             emit mentionFriendStatus(QString::fromStdString(response.username), response.status);
             break;
         }
         
         case FRIEND_REQUEST_FORWARD: {
             friendRequestForward response(reinterpret_cast<unsigned char*>(packet));
-            qDebug() << "Received a friend request forward packet from " << response.from;
             emit mentionFriendRequest(QString::fromStdString(response.from));
             break;
         }
         
         case FRIEND_REQUEST_RESPONSE: {
             friendRequestResponse response(reinterpret_cast<unsigned char*>(packet));
-            qDebug() << "Received a friend request response packet - request from " << response.from << " to " << response.to << " saying " << response.response;
             emit mentionFriendResponse(QString::fromStdString(response.to), response.response);
             break;
         }

--- a/src/app/clientsocket.cpp
+++ b/src/app/clientsocket.cpp
@@ -84,7 +84,7 @@ void ClientSocketManager::sendFriendRequest(QString friend_name)
     sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
 }
 
-void ClientSocketManager::sendFriendRequestResponse(QString friend_name, FriendRequestResponse response)
+void ClientSocketManager::sendFriendResponse(QString friend_name, FriendRequestResponse response)
 {
     if (sock->state() != QAbstractSocket::ConnectedState) {
         qDebug() << "Not connected to server";
@@ -136,19 +136,22 @@ void ClientSocketManager::handlePacket(char *packet)
         
         case FRIEND_STATUS_UPDATE: {
             friendStatusUpdate response(reinterpret_cast<unsigned char*>(packet));
+            qDebug() << "Received a status update packet stating that " << response.username << " is " << response.status;
             emit mentionFriendStatus(QString::fromStdString(response.username), response.status);
             break;
         }
         
         case FRIEND_REQUEST_FORWARD: {
             friendRequestForward response(reinterpret_cast<unsigned char*>(packet));
+            qDebug() << "Received a friend request forward packet from " << response.from;
             emit mentionFriendRequest(QString::fromStdString(response.from));
             break;
         }
         
         case FRIEND_REQUEST_RESPONSE: {
             friendRequestResponse response(reinterpret_cast<unsigned char*>(packet));
-            emit mentionFriendRequestResponse(QString::fromStdString(response.from), response.response);
+            qDebug() << "Received a friend request response packet - request from " << response.from << " to " << response.to << " saying " << response.response;
+            emit mentionFriendResponse(QString::fromStdString(response.to), response.response);
             break;
         }
         

--- a/src/app/clientsocket.cpp
+++ b/src/app/clientsocket.cpp
@@ -117,8 +117,8 @@ void ClientSocketManager::sendMessage(QString friend_name, QString message)
     
     messageSend packet(message.toStdString(), friend_name.toStdString());
     unsigned char buffer[PACKET_BUFFER_SIZE];
-    while (packet.write_to_packet(buffer)) sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
-    sock->write(reinterpret_cast<const char*>(buffer), bytesWritten);
+    while (packet.write_to_packet(buffer)) sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
+    sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
 }
 
 // Private method to handle incoming packets and emit signals
@@ -126,7 +126,8 @@ void ClientSocketManager::handlePacket(char *packet)
 {
     // First byte contains the packet type
     PacketFromServerType packetType = static_cast<PacketFromServerType>(packet[0]);
-    
+    unsigned char buffer[PACKET_BUFFER_SIZE];
+
     switch (packetType) {
         case ACCOUNT_RESULT: {
             createAccountResponse response(reinterpret_cast<unsigned char*>(packet));
@@ -163,8 +164,8 @@ void ClientSocketManager::handlePacket(char *packet)
         case MESSAGE_FORWARD: {
             messageForward response(reinterpret_cast<unsigned char*>(packet));
             if (response.bytes_remaining) {
-                sock->read(buffer, PACKET_BUFFER_SIZE);
-                while(response.read_from_packet(buffer)) sock->read(buffer, PACKET_BUFFER_SIZE);
+                sock->read((char *)buffer, PACKET_BUFFER_SIZE);
+                while(response.read_from_packet(buffer)) sock->read((char *)buffer, PACKET_BUFFER_SIZE);
             }
             emit mentionMessage(QString::fromStdString(response.sender), QString::fromStdString(response.message));
             break;

--- a/src/app/clientsocket.h
+++ b/src/app/clientsocket.h
@@ -19,14 +19,14 @@ signals:
     void mentionLoginSuccess();
     void mentionFriendStatus(QString friend_name, FriendStatus status);
     void mentionFriendRequest(QString friend_name);
-    void mentionFriendRequestResponse(QString friend_name, FriendRequestResponse response);
+    void mentionFriendResponse(QString friend_name, FriendRequestResponse response);
     void mentionMessage(QString friend_name, QString message);
 
 public slots:
     void sendAccountRequest(QString user_name, QString password);
     void sendLoginRequest(QString user_name, QString password);
     void sendFriendRequest(QString friend_name);
-    void sendFriendRequestResponse(QString friend_name, FriendRequestResponse response);
+    void sendFriendResponse(QString friend_name, FriendRequestResponse response);
     void sendMessage(QString friend_name, QString message);
 
 private:

--- a/src/app/clientsocket.h
+++ b/src/app/clientsocket.h
@@ -12,7 +12,7 @@ public:
     explicit ClientSocketManager(QString server_address, QObject *parent = nullptr);
     ~ClientSocketManager();
 
-// slots
+public slots:
     void sendAccountRequest(QString user_name, QString password);
     void sendLoginRequest(QString user_name, QString password);
     void sendFriendRequest(QString friend);
@@ -20,8 +20,9 @@ public:
     void sendMessage(QString friend, QString message);
 
 signals:
-    void mentionAccountResult(bool success, QString reason);
-    void mentionLoginResult(bool success, QString reason);
+    void mentionAccountResult(QString reason);
+    void mentionLoginResult(QString reason);
+    void mentionLoginSuccess();
     void mentionFriendStatus(QString friend, FriendStatus status);
     void mentionFriendRequest(QString friend);
     void mentionFriendRequestResponse(QString friend, FriendRequestResponse response);
@@ -30,6 +31,7 @@ signals:
 private:
     void handlePacket(char * packet);
     QTcpSocket * sock;
+    QString connectedUser;
 };
 
 #endif 

--- a/src/app/clientsocket.h
+++ b/src/app/clientsocket.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include "packet.h"
+#include <QTcpSocket>
 
 class ClientSocketManager : public QObject 
 {
@@ -11,22 +12,22 @@ class ClientSocketManager : public QObject
 public:
     explicit ClientSocketManager(QString server_address, QObject *parent = nullptr);
     ~ClientSocketManager();
-
-public slots:
-    void sendAccountRequest(QString user_name, QString password);
-    void sendLoginRequest(QString user_name, QString password);
-    void sendFriendRequest(QString friend);
-    void sendFriendRequestResponse(QString friend, FriendRequestResponse response);
-    void sendMessage(QString friend, QString message);
-
+    
 signals:
     void mentionAccountResult(QString reason);
     void mentionLoginResult(QString reason);
     void mentionLoginSuccess();
-    void mentionFriendStatus(QString friend, FriendStatus status);
-    void mentionFriendRequest(QString friend);
-    void mentionFriendRequestResponse(QString friend, FriendRequestResponse response);
-    void mentionMessage(QString friend, QString message);
+    void mentionFriendStatus(QString friend_name, FriendStatus status);
+    void mentionFriendRequest(QString friend_name);
+    void mentionFriendRequestResponse(QString friend_name, FriendRequestResponse response);
+    void mentionMessage(QString friend_name, QString message);
+
+public slots:
+    void sendAccountRequest(QString user_name, QString password);
+    void sendLoginRequest(QString user_name, QString password);
+    void sendFriendRequest(QString friend_name);
+    void sendFriendRequestResponse(QString friend_name, FriendRequestResponse response);
+    void sendMessage(QString friend_name, QString message);
 
 private:
     void handlePacket(char * packet);

--- a/src/app/clientsocket.h
+++ b/src/app/clientsocket.h
@@ -1,0 +1,35 @@
+#ifndef SOCKET_H
+#define SOCKET_H
+
+#include <QObject>
+#include "packet.h"
+
+class ClientSocketManager : public QObject 
+{
+    Q_OBJECT 
+
+public:
+    explicit ClientSocketManager(QString server_address, QObject *parent = nullptr);
+    ~ClientSocketManager();
+
+// slots
+    void sendAccountRequest(QString user_name, QString password);
+    void sendLoginRequest(QString user_name, QString password);
+    void sendFriendRequest(QString friend);
+    void sendFriendRequestResponse(QString friend, FriendRequestResponse response);
+    void sendMessage(QString friend, QString message);
+
+signals:
+    void mentionAccountResult(bool success, QString reason);
+    void mentionLoginResult(bool success, QString reason);
+    void mentionFriendStatus(QString friend, FriendStatus status);
+    void mentionFriendRequest(QString friend);
+    void mentionFriendRequestResponse(QString friend, FriendRequestResponse response);
+    void mentionMessage(QString friend, QString message);
+
+private:
+    void handlePacket(char * packet);
+    QTcpSocket * sock;
+};
+
+#endif 

--- a/src/app/codebox.cpp
+++ b/src/app/codebox.cpp
@@ -10,8 +10,8 @@
 #include <string>
 #include <sstream>
 
-CodeBox::CodeBox(QTcpSocket *socket, QWidget *parent)
-    : QWidget(parent), sock(socket), current_codebook(nullptr)
+CodeBox::CodeBox(QWidget *parent)
+    : QWidget(parent), current_codebook(nullptr)
 {
     layout = new QVBoxLayout(this);
     
@@ -71,7 +71,7 @@ void CodeBox::decryptAndReceiveMessage(QString message, QString sender)
 {
     if (!current_codebook) {
         qDebug() << "No codebook selected for decryption";
-        reportDecryptedMessage(message, recipient);
+        reportDecryptedMessage(message, false, sender);
         return;
     }
     
@@ -85,7 +85,7 @@ void CodeBox::decryptAndReceiveMessage(QString message, QString sender)
     std::ostringstream plainStream(decryptedMessage);
     decrypt(cipherStream, plainStream, *current_codebook);
     
-    reportDecryptedMessage(QString::fromStdString(decryptedMessage), sender);
+    reportDecryptedMessage(QString::fromStdString(decryptedMessage), false, sender);
 }
 
 void CodeBox::addNewCodebook()

--- a/src/app/codebox.cpp
+++ b/src/app/codebox.cpp
@@ -1,0 +1,142 @@
+#include "codebox.h"
+#include "../server/packet.h"
+#include "../crypt/encrypt.h"
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QDebug>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QFileInfo>
+#include <string>
+#include <sstream>
+
+CodeBox::CodeBox(QTcpSocket *socket, QWidget *parent)
+    : QWidget(parent), sock(socket), current_codebook(nullptr)
+{
+    layout = new QVBoxLayout(this);
+    
+    // Create combo box for codebook selection
+    QHBoxLayout *comboLayout = new QHBoxLayout();
+    QLabel *codebookLabel = new QLabel("Codebook:", this);
+    codebookComboBox = new QComboBox(this);
+    comboLayout->addWidget(codebookLabel);
+    comboLayout->addWidget(codebookComboBox);
+    layout->addLayout(comboLayout);
+    
+    // Create button to add new codebook
+    addCodebookPushButton = new QPushButton("Add Codebook", this);
+    layout->addWidget(addCodebookPushButton);
+    
+    // Connect button to addNewCodebook function
+    connect(addCodebookPushButton, &QPushButton::clicked, this, &CodeBox::addNewCodebook);
+    
+    // Connect combo box selection change
+    connect(codebookComboBox, QOverload<const QString &>::of(&QComboBox::currentTextChanged),
+            [this](const QString &text) {
+                if (codebooks.contains(text)) {
+                    current_codebook = codebooks[text];
+                } else {
+                    current_codebook = nullptr;
+                }
+            });
+}
+
+CodeBox::~CodeBox()
+{
+    // Qt will handle cleanup of child widgets
+}
+
+void CodeBox::encryptAndSendMessage(QString message, QString target)
+{
+    if (!current_codebook) {
+        qDebug() << "No codebook selected for encryption";
+        return;
+    }
+    
+    // Convert QString to std::string for encryption
+    std::string messageStr = message.toStdString();
+    std::string targetStr = target.toStdString();
+    
+    // Encrypt the message using the current codebook
+    std::string encryptedMessage;
+    
+    std::istringstream messageStream(messageStr);
+    std::ostringstream cipherStream(encryptedMessage);
+    encrypt(messageStream, cipherStream, *current_codebook);
+    
+    // Create messageSend packet
+    messageSend packet(encryptedMessage, targetStr);
+    
+    // Write packet to buffer
+    unsigned char buffer[PACKET_BUFFER_SIZE];
+    packet.write_to_packet(buffer);
+    
+    // Send packet through socket
+    if (sock && sock->state() == QAbstractSocket::ConnectedState) {
+        sock->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
+        sock->flush();
+        qDebug() << "Encrypted message sent to" << target;
+    } else {
+        qDebug() << "Socket not connected, cannot send message";
+    }
+}
+
+void CodeBox::addNewCodebook()
+{
+    // Open file dialog to select codebook file
+    QString fileName = QFileDialog::getOpenFileName(
+        this,
+        "Select Codebook File",
+        "",
+        "Codebook Files (*.cbk);;All Files (*)"
+    );
+    
+    if (fileName.isEmpty()) {
+        return; // User cancelled
+    }
+    
+    // Extract just the filename without path for the map key
+    QFileInfo fileInfo(fileName);
+    QString codebookName = fileInfo.fileName();
+    
+    // Check if codebook with this name already exists
+    if (codebooks.contains(codebookName)) {
+        QMessageBox::warning(this, "Codebook Exists", 
+                           "A codebook with this name already exists.");
+        return;
+    }
+    
+    // Create a new FullCodebook and try to read from file
+    try {
+        std::shared_ptr<FullCodebook> newCodebook = std::make_shared<FullCodebook>(""); // Empty keyword, will be loaded from file
+        std::string filePath = fileName.toStdString();
+        
+        if (newCodebook->read_from_file(filePath)) {
+            // Verify the codebook is valid
+            if (newCodebook->verify()) {
+                // Add to map
+                codebooks[codebookName] = newCodebook;
+                
+                // Add to combo box
+                codebookComboBox->addItem(codebookName);
+                
+                // If this is the first codebook, select it
+                if (codebookComboBox->count() == 1) {
+                    codebookComboBox->setCurrentText(codebookName);
+                    current_codebook = codebooks[codebookName];
+                }
+                
+                qDebug() << "Successfully loaded codebook:" << codebookName;
+            } else {
+                QMessageBox::warning(this, "Invalid Codebook", 
+                                   "The selected file is not a valid codebook.");
+            }
+        } else {
+            QMessageBox::warning(this, "File Error", 
+                               "Failed to read the codebook file.");
+        }
+    } catch (const std::exception &e) {
+        QMessageBox::critical(this, "Error", 
+                            QString("Error loading codebook: %1").arg(e.what()));
+    }
+}

--- a/src/app/codebox.h
+++ b/src/app/codebox.h
@@ -18,10 +18,14 @@ public:
     explicit CodeBox(QTcpSocket *socket, QWidget *parent = nullptr);
     ~CodeBox();
     
-    void encryptAndSendMessage(QString message, QString target);
+public signals:
+    void requestMessageSend(QString message, QString recipient);
+    void reportDecryptedMessage(QString message, QString sender);
+public slots:
+    void encryptAndSendMessage(QString message, QString recipient);
+    void decryptAndReceiveMessage(QString message, QString sender);
 
 private:
-    QTcpSocket *sock;
     QVBoxLayout *layout;
     QMap<QString, std::shared_ptr<FullCodebook>> codebooks;
     QPushButton *addCodebookPushButton;

--- a/src/app/codebox.h
+++ b/src/app/codebox.h
@@ -15,12 +15,12 @@ class CodeBox : public QWidget
     Q_OBJECT
 
 public:
-    explicit CodeBox(QTcpSocket *socket, QWidget *parent = nullptr);
+    explicit CodeBox(QWidget *parent = nullptr);
     ~CodeBox();
     
-public signals:
+signals:
     void requestMessageSend(QString message, QString recipient);
-    void reportDecryptedMessage(QString message, QString sender);
+    void reportDecryptedMessage(QString message, bool original, QString sender);
 public slots:
     void encryptAndSendMessage(QString message, QString recipient);
     void decryptAndReceiveMessage(QString message, QString sender);

--- a/src/app/codebox.h
+++ b/src/app/codebox.h
@@ -17,6 +17,8 @@ class CodeBox : public QWidget
 public:
     explicit CodeBox(QTcpSocket *socket, QWidget *parent = nullptr);
     ~CodeBox();
+    
+    void encryptAndSendMessage(QString message, QString target);
 
 private:
     QTcpSocket *sock;
@@ -26,7 +28,6 @@ private:
     std::shared_ptr<FullCodebook> current_codebook;
     QComboBox *codebookComboBox;
 
-    void encryptAndSendMessage(QString message, QString target);
     void addNewCodebook();
 };
 

--- a/src/app/codebox.h
+++ b/src/app/codebox.h
@@ -1,0 +1,33 @@
+#ifndef CODEBOX_H
+#define CODEBOX_H
+
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QMap>
+#include <QPushButton>
+#include <QComboBox>
+#include <QTcpSocket>
+#include "../crypt/codebook.h"
+#include <memory>
+
+class CodeBox : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit CodeBox(QTcpSocket *socket, QWidget *parent = nullptr);
+    ~CodeBox();
+
+private:
+    QTcpSocket *sock;
+    QVBoxLayout *layout;
+    QMap<QString, std::shared_ptr<FullCodebook>> codebooks;
+    QPushButton *addCodebookPushButton;
+    std::shared_ptr<FullCodebook> current_codebook;
+    QComboBox *codebookComboBox;
+
+    void encryptAndSendMessage(QString message, QString target);
+    void addNewCodebook();
+};
+
+#endif // CODEBOX_H

--- a/src/app/database.cpp
+++ b/src/app/database.cpp
@@ -1,0 +1,220 @@
+#include "database.h"
+#include <QDebug>
+
+ClientDatabaseManager::ClientDatabaseManager(QObject *parent)
+    : QObject(parent)
+    , database(nullptr)
+{
+    // Initialize SQLite database
+    int rc = sqlite3_open("client.db", &database);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to open database:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    // Create friends table (without status field)
+    const char* createFriendsTable = 
+        "CREATE TABLE IF NOT EXISTS friends ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "friend_name TEXT NOT NULL)";
+
+    rc = sqlite3_exec(database, createFriendsTable, nullptr, nullptr, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to create friends table:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    // Create messages table
+    const char* createMessagesTable = 
+        "CREATE TABLE IF NOT EXISTS messages ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "friend_id INTEGER NOT NULL, "
+        "message TEXT NOT NULL, "
+        "original BOOLEAN NOT NULL, "
+        "FOREIGN KEY (friend_id) REFERENCES friends (id))";
+
+    rc = sqlite3_exec(database, createMessagesTable, nullptr, nullptr, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to create messages table:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    qDebug() << "Database initialized successfully";
+}
+
+ClientDatabaseManager::~ClientDatabaseManager()
+{
+    if (database) {
+        sqlite3_close(database);
+        database = nullptr;
+    }
+}
+
+void ClientDatabaseManager::insertFriend(QString name)
+{
+    if (!database) return;
+
+    const char* sql = "INSERT INTO friends (friend_name) VALUES (?)";
+    sqlite3_stmt* stmt;
+    
+    int rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to prepare insert friend statement:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    sqlite3_bind_text(stmt, 1, name.toUtf8().constData(), -1, SQLITE_STATIC);
+    
+    rc = sqlite3_step(stmt);
+    if (rc != SQLITE_DONE) {
+        qDebug() << "Failed to insert friend:" << sqlite3_errmsg(database);
+    }
+
+    sqlite3_finalize(stmt);
+}
+
+void ClientDatabaseManager::insertMessage(QString message, bool original, QString friend)
+{
+    if (!database) return;
+
+    // First get the friend_id from the friends table
+    const char* getFriendIdSql = "SELECT id FROM friends WHERE friend_name = ?";
+    sqlite3_stmt* getFriendStmt;
+    
+    int rc = sqlite3_prepare_v2(database, getFriendIdSql, -1, &getFriendStmt, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to prepare get friend id statement:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    sqlite3_bind_text(getFriendStmt, 1, friend.toUtf8().constData(), -1, SQLITE_STATIC);
+    
+    int friendId = -1;
+    if (sqlite3_step(getFriendStmt) == SQLITE_ROW) {
+        friendId = sqlite3_column_int(getFriendStmt, 0);
+    }
+    
+    sqlite3_finalize(getFriendStmt);
+    
+    if (friendId == -1) {
+        qDebug() << "Friend not found:" << friend;
+        return;
+    }
+
+    // Insert the message
+    const char* insertMessageSql = "INSERT INTO messages (friend_id, message, original) VALUES (?, ?, ?)";
+    sqlite3_stmt* insertStmt;
+    
+    rc = sqlite3_prepare_v2(database, insertMessageSql, -1, &insertStmt, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to prepare insert message statement:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    sqlite3_bind_int(insertStmt, 1, friendId);
+    sqlite3_bind_text(insertStmt, 2, message.toUtf8().constData(), -1, SQLITE_STATIC);
+    sqlite3_bind_int(insertStmt, 3, original ? 1 : 0);
+    
+    rc = sqlite3_step(insertStmt);
+    if (rc != SQLITE_DONE) {
+        qDebug() << "Failed to insert message:" << sqlite3_errmsg(database);
+    }
+
+    sqlite3_finalize(insertStmt);
+}
+
+void ClientDatabaseManager::queryFriends()
+{
+    if (!database) return;
+
+    std::vector<QString> friends;
+    const char* sql = "SELECT friend_name FROM friends ORDER BY friend_name";
+    sqlite3_stmt* stmt;
+    
+    int rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to prepare query friends statement:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char* friendName = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+        friends.push_back(QString::fromUtf8(friendName));
+    }
+
+    sqlite3_finalize(stmt);
+    
+    emit outputFriendList(friends);
+}
+
+void ClientDatabaseManager::queryMessages(QString friend, int count, int before)
+{
+    if (!database) return;
+
+    // First get the friend_id
+    const char* getFriendIdSql = "SELECT id FROM friends WHERE friend_name = ?";
+    sqlite3_stmt* getFriendStmt;
+    
+    int rc = sqlite3_prepare_v2(database, getFriendIdSql, -1, &getFriendStmt, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to prepare get friend id statement:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    sqlite3_bind_text(getFriendStmt, 1, friend.toUtf8().constData(), -1, SQLITE_STATIC);
+    
+    int friendId = -1;
+    if (sqlite3_step(getFriendStmt) == SQLITE_ROW) {
+        friendId = sqlite3_column_int(getFriendStmt, 0);
+    }
+    
+    sqlite3_finalize(getFriendStmt);
+    
+    if (friendId == -1) {
+        qDebug() << "Friend not found:" << friend;
+        return;
+    }
+
+    // Query messages
+    std::vector<std::tuple<QString, bool>> messages;
+    int firstMessageId = 0;
+    
+    const char* sql;
+    if (before > 0) {
+        sql = "SELECT id, message, original FROM messages WHERE friend_id = ? AND id < ? ORDER BY id DESC LIMIT ?";
+    } else {
+        sql = "SELECT id, message, original FROM messages WHERE friend_id = ? ORDER BY id DESC LIMIT ?";
+    }
+    
+    sqlite3_stmt* stmt;
+    rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to prepare query messages statement:" << sqlite3_errmsg(database);
+        return;
+    }
+
+    if (before > 0) {
+        sqlite3_bind_int(stmt, 1, friendId);
+        sqlite3_bind_int(stmt, 2, before);
+        sqlite3_bind_int(stmt, 3, count);
+    } else {
+        sqlite3_bind_int(stmt, 1, friendId);
+        sqlite3_bind_int(stmt, 2, count);
+    }
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        int id = sqlite3_column_int(stmt, 0);
+        const char* message = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+        bool original = sqlite3_column_int(stmt, 2) != 0;
+        
+        if (firstMessageId == 0) {
+            firstMessageId = id;
+        }
+        
+        messages.push_back(std::make_tuple(QString::fromUtf8(message), original));
+    }
+
+    sqlite3_finalize(stmt);
+    
+    emit outputMessageQuery(messages, firstMessageId);
+}

--- a/src/app/database.cpp
+++ b/src/app/database.cpp
@@ -124,7 +124,8 @@ void ClientDatabaseManager::insertMessage(QString message, bool original, QStrin
         return;
     }
 
-    sqlite3_bind_text(getFriendStmt, 1, friend_name.toUtf8().constData(), -1, SQLITE_STATIC);
+    std::string namechars = friend_name.toStdString();
+    sqlite3_bind_text(getFriendStmt, 1, namechars.c_str(), -1, SQLITE_STATIC);
     
     int friendId = -1;
     if (sqlite3_step(getFriendStmt) == SQLITE_ROW) {
@@ -206,7 +207,8 @@ void ClientDatabaseManager::queryMessages(QString friend_name, int count, int be
         return;
     }
 
-    sqlite3_bind_text(getFriendStmt, 1, friend_name.toUtf8().constData(), -1, SQLITE_STATIC);
+    std::string name_as_str = friend_name.toStdString();
+    sqlite3_bind_text(getFriendStmt, 1, name_as_str.c_str(), -1, SQLITE_STATIC);
     
     int friendId = -1;
     if (sqlite3_step(getFriendStmt) == SQLITE_ROW) {

--- a/src/app/database.cpp
+++ b/src/app/database.cpp
@@ -7,7 +7,7 @@ ClientDatabaseManager::ClientDatabaseManager(QObject *parent)
     , database(nullptr)
 {
     // Initialize SQLite database
-    int rc = sqlite3_open("client.db", &database);
+    int rc = sqlite3_open("PIT.db", &database);
     if (rc != SQLITE_OK) {
         qDebug() << "Failed to open database:" << sqlite3_errmsg(database);
         return;
@@ -184,6 +184,7 @@ void ClientDatabaseManager::queryFriends()
 
     sqlite3_finalize(stmt);
     
+    qDebug() << "About to output a list of friends of length " << friends.size();
     emit outputFriendList(friends);
 }
 

--- a/src/app/database.h
+++ b/src/app/database.h
@@ -14,11 +14,13 @@ public:
     explicit ClientDatabaseManager(QObject *parent = nullptr);
     ~ClientDatabaseManager();
 
+    bool hasFriend(QString name);
+
     // inserts a friend with the given name into the friends database
     void insertFriend(QString name);
 
     // inserts a message with the given text, originality, and attributed friend into the messages database
-    void insertMessage(QString message, bool original, QString friend);
+    void insertMessage(QString message, bool original, QString friend = "");
 
     // requests that a vector of the names of all currently known friends
     // be retrieved and sent by signal outputFriendList
@@ -27,12 +29,15 @@ public:
     // requests that the last *count* messages from the friend chosen
     // with ID less than before (or the last ten at all, if before is zero)
     // be retrieved and send by outputMessageQuery
-    void queryMessages(QString friend, int count, int before);
+    void queryMessages(int friend_id, int count = 10, int before = 0);
     
 signals:
     void outputFriendList(std::vector<QString> friends);
     void outputMessageQuery(std::vector<std::tuple<QString, bool>> messages, int first_message_id);
+    void reportIncomingMessage(QString message, bool original);
+    void reportOutgoingMessage(QString message, QString recipient);
 
 private:
     sqlite3 * database;
+    QString queried_friend = "";
 };

--- a/src/app/database.h
+++ b/src/app/database.h
@@ -20,7 +20,7 @@ public:
     void insertFriend(QString name);
 
     // inserts a message with the given text, originality, and attributed friend into the messages database
-    void insertMessage(QString message, bool original, QString friend = "");
+    void insertMessage(QString message, bool original, QString friend_name = "");
 
     // requests that a vector of the names of all currently known friends
     // be retrieved and sent by signal outputFriendList
@@ -29,15 +29,19 @@ public:
     // requests that the last *count* messages from the friend chosen
     // with ID less than before (or the last ten at all, if before is zero)
     // be retrieved and send by outputMessageQuery
-    void queryMessages(int friend_id, int count = 10, int before = 0);
+    void queryFriendMessages(QString friend_name);
+    void queryMessages(QString friend_name, int count = 10, int before = 0);
     
 signals:
     void outputFriendList(std::vector<QString> friends);
     void outputMessageQuery(std::vector<std::tuple<QString, bool>> messages, int first_message_id);
     void reportIncomingMessage(QString message, bool original);
     void reportOutgoingMessage(QString message, QString recipient);
+    void reportNewFriend(int id, QString name, int status);
 
 private:
     sqlite3 * database;
     QString queried_friend = "";
 };
+
+#endif DATABASE_H

--- a/src/app/database.h
+++ b/src/app/database.h
@@ -1,0 +1,38 @@
+#ifndef DATABASE_H
+#define DATABASE_H
+
+#include <QObject>
+#include <vector>
+#include <string>
+#include <sqlite3.h>
+
+class ClientDatabaseManager : public QObject 
+{
+    Q_OBJECT
+
+public:
+    explicit ClientDatabaseManager(QObject *parent = nullptr);
+    ~ClientDatabaseManager();
+
+    // inserts a friend with the given name into the friends database
+    void insertFriend(QString name);
+
+    // inserts a message with the given text, originality, and attributed friend into the messages database
+    void insertMessage(QString message, bool original, QString friend);
+
+    // requests that a vector of the names of all currently known friends
+    // be retrieved and sent by signal outputFriendList
+    void queryFriends();
+
+    // requests that the last *count* messages from the friend chosen
+    // with ID less than before (or the last ten at all, if before is zero)
+    // be retrieved and send by outputMessageQuery
+    void queryMessages(QString friend, int count, int before);
+    
+signals:
+    void outputFriendList(std::vector<QString> friends);
+    void outputMessageQuery(std::vector<std::tuple<QString, bool>> messages, int first_message_id);
+
+private:
+    sqlite3 * database;
+};

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -58,14 +58,17 @@ void FriendsBox::addFriend(int id, const QString &name, int status)
 
 void FriendsBox::handlePacket(unsigned char *packet)
 {
+    std::cout << "Friends box received a packet of type: ";
     switch (*packet) {
         case PacketFromServerType::FRIEND_STATUS_UPDATE: {
+            std::cout << "friend status update.\n";
             friendStatusUpdate statusUpdate(packet);
             QString username = QString::fromStdString(statusUpdate.username);
             updateFriendStatus(username, static_cast<int>(statusUpdate.status));
             break;
         }
         case PacketFromServerType::FRIEND_REQUEST_RESPONSE: {
+            std::cout << "friend request response.\n";
             friendRequestResponse response(packet);
             QString from = QString::fromStdString(response.from);
             if (response.response == FriendRequestResponse::ACCEPT) {

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -45,6 +45,7 @@ void FriendsBox::processFriendList(std::vector<QString> names) {
     int i = 0;
     while (i < names.size()) {
         addNewFriend(i, names[i], FriendStatus::OFFLINE);
+        ++i;
     }
 }
 

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -9,7 +9,7 @@
 #include <QString>
 
 FriendsBox::FriendsBox(sqlite3 *db, QWidget *parent)
-    : QWidget(parent), database(db)
+    : QWidget(parent), database(db), selectedFriendId(-1)
 {
     layout = new QVBoxLayout(this);
     layout->setSpacing(5);
@@ -56,6 +56,7 @@ void FriendsBox::addFriend(int id, const QString &name, int status)
     
     connect(friendBox, &FriendBox::friendClicked, this, [this](int friendId) {
         qDebug() << "Friend clicked:" << friendId;
+        selectedFriendId = friendId;
         emit friendSelected(friendId);
     });
 }
@@ -208,4 +209,31 @@ void FriendBox::mousePressEvent(QMouseEvent *event)
         emit friendClicked(friendId);
     }
     QWidget::mousePressEvent(event);
+}
+
+// FriendsBox methods for getting selected friend information
+int FriendsBox::getSelectedFriendId() const
+{
+    return selectedFriendId;
+}
+
+QString FriendsBox::getSelectedFriendName() const
+{
+    if (selectedFriendId > 0 && friendWidgets.contains(selectedFriendId)) {
+        return friendWidgets[selectedFriendId]->friendName;
+    }
+    return QString();
+}
+
+int FriendsBox::getSelectedFriendStatus() const
+{
+    if (selectedFriendId > 0 && friendWidgets.contains(selectedFriendId)) {
+        return friendWidgets[selectedFriendId]->friendStatus;
+    }
+    return FriendStatus::OFFLINE;
+}
+
+bool FriendsBox::hasSelectedFriend() const
+{
+    return selectedFriendId > 0 && friendWidgets.contains(selectedFriendId);
 }

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -80,8 +80,13 @@ void FriendsBox::handlePacket(unsigned char *packet)
 }
 
 void FriendsBox::updateFriendStatus(const QString &username, int status)
-{
-    if (friendNameToId.contains(username)) {
+{   
+    int id = friendNameToId.contains(username) ? friendNameToId[username] : insertFriendToDatabase(username, status);
+    if (id == -1) {
+        qDebug() << "Error inserting new friend into database";
+        return;
+    }
+    if (!friendNameToId.contains(username)) {
         int id = friendNameToId[username];
         if (friendWidgets.contains(id)) {
             friendWidgets[id]->updateStatus(status);

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -51,7 +51,10 @@ void FriendsBox::processFriendList(std::vector<QString> names) {
 
 void FriendsBox::updateFriendStatus(const QString &username, int status)
 {   
-    if (!friendNameToId.contains(username)) addNewFriend(friendNameToId.size(), username, status);
+    if (!friendNameToId.contains(username)) {
+        addNewFriend(friendNameToId.size(), username, status);
+        reportNewFriend(username);
+    }
     else {
         int id = friendNameToId[username];
         if (friendWidgets.contains(id)) {

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -52,7 +52,7 @@ void FriendsBox::addFriend(int id, const QString &name, int status)
     
     connect(friendBox, &FriendBox::friendClicked, this, [this](int friendId) {
         qDebug() << "Friend clicked:" << friendId;
-        // Emit signal or handle friend selection
+        emit friendSelected(friendId);
     });
 }
 

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -23,32 +23,13 @@ FriendsBox::~FriendsBox()
     // Qt will delete child widgets automatically
 }
 
-void FriendsBox::loadFriends()
-{
-    const char *sql = "SELECT id, friend_name, status FROM friends ORDER BY friend_name";
-    sqlite3_stmt *stmt;
-    
-    int rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
-    if (rc != SQLITE_OK) {
-        qDebug() << "Failed to prepare statement:" << sqlite3_errmsg(database);
-        return;
-    }
-    
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
-        int id = sqlite3_column_int(stmt, 0);
-        const char *name = (const char*)sqlite3_column_text(stmt, 1);
-        int status = sqlite3_column_int(stmt, 2);
-
-        qDebug() << "We have a friend named: " << name;
-        
-        addFriend(id, QString::fromUtf8(name), status);
-    }
-    
-    sqlite3_finalize(stmt);
-}
-
 void FriendsBox::addFriend(int id, const QString &name, int status)
 {
+    if (friendWidgets.contains(id) || friendNameToId.contains(name)) {
+        qDebug() << "Adding duplicate friend";
+        return;
+    }
+
     FriendBox *friendBox = new FriendBox(id, name, status, this);
     friendWidgets[id] = friendBox;
     friendNameToId[name] = id;
@@ -60,6 +41,14 @@ void FriendsBox::addFriend(int id, const QString &name, int status)
         emit friendSelected(friendId);
     });
 }
+
+void FriendsBox::processFriendList(vector<QString> names) {
+    int i = 0;
+    while (i < names.size()) {
+        addFriend(i, names[i], FriendStatus::OFFLINE);
+    }
+}
+
 
 void FriendsBox::handlePacket(unsigned char *packet)
 {
@@ -87,87 +76,15 @@ void FriendsBox::handlePacket(unsigned char *packet)
 
 void FriendsBox::updateFriendStatus(const QString &username, int status)
 {   
-    if (!friendNameToId.contains(username)) addNewFriend(username, status);
+    if (!friendNameToId.contains(username)) addFriend(friendNameToId.size(), username, status);
     else {
         int id = friendNameToId[username];
         if (friendWidgets.contains(id)) {
             friendWidgets[id]->updateStatus(status);
-            
-            // Update database
-            const char *sql = "UPDATE friends SET status = ? WHERE id = ?";
-            sqlite3_stmt *stmt;
-            int rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
-            if (rc == SQLITE_OK) {
-                sqlite3_bind_int(stmt, 1, status);
-                sqlite3_bind_int(stmt, 2, id);
-                sqlite3_step(stmt);
-                sqlite3_finalize(stmt);
-            }
         }
     }
 }
 
-void FriendsBox::addNewFriend(const QString &username, int status)
-{
-    // Check if friend already exists
-    if (friendNameToId.contains(username)) {
-        return;
-    }
-    
-    int id = insertFriendToDatabase(username, status);
-    if (id > 0) {
-        addFriend(id, username, status);
-    }
-}
-
-int FriendsBox::insertFriendToDatabase(const QString &name, int status)
-{
-    std::string namechars = name.toStdString();
-
-    const char *sql_chk = "SELECT COUNT(*) FROM friends WHERE friend_name = ? ;";
-    sqlite3_stmt *stmt_chk;
-    int rc = sqlite3_prepare_v2(database, sql_chk, -1, &stmt_chk, nullptr);
-    if (rc != SQLITE_OK) {
-        qDebug() << "Failed to prepare statement:" << sqlite3_errmsg(database);
-        return -1;
-    }
-    sqlite3_bind_text(stmt_chk, 1, namechars.c_str(), -1, SQLITE_STATIC);
-    rc = sqlite3_step(stmt_chk);
-    int ans = sqlite3_column_int(stmt_chk, 0);
-    sqlite3_finalize(stmt_chk);
-
-    if (ans) {
-        qDebug() << "Caution!  Attempted to add duplicate friend " << name << "to database.";
-        return -1;
-    }
-
-    const char *sql = "INSERT INTO friends (friend_name, status) VALUES (?, ?)";
-    sqlite3_stmt *stmt;
-    
-    rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
-    if (rc != SQLITE_OK) {
-        qDebug() << "Failed to prepare statement:" << sqlite3_errmsg(database);
-        return -1;
-    }
-
-    qDebug() << "Name of friend added to database: " << name;
-    
-    
-
-    qDebug() << "Bound as: " << QString::fromStdString(std::string(namechars.c_str()));
-
-    sqlite3_bind_text(stmt, 1, namechars.c_str(), -1, SQLITE_STATIC);
-    sqlite3_bind_int(stmt, 2, status);
-    
-    rc = sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-    
-    if (rc == SQLITE_DONE) {
-        return sqlite3_last_insert_rowid(database);
-    }
-    
-    return -1;
-}
 
 FriendBox::FriendBox(int friendId, const QString &name, int status, QWidget *parent)
     : QWidget(parent), friendId(friendId), friendName(name), friendStatus(status)

--- a/src/app/friendsbox.cpp
+++ b/src/app/friendsbox.cpp
@@ -132,8 +132,11 @@ int FriendsBox::insertFriendToDatabase(const QString &name, int status)
 
     qDebug() << "Name of friend added to database: " << name;
     
-    // THIS IS ADDING RANDOM CHARACTERS TO THE DATABASE!!!
-    sqlite3_bind_text(stmt, 1, name.toUtf8().constData(), -1, SQLITE_STATIC);
+    std::string namechars = name.toStdString();
+
+    qDebug() << "Bound as: " << QString::fromStdString(std::string(namechars.c_str()));
+
+    sqlite3_bind_text(stmt, 1, namechars.c_str(), -1, SQLITE_STATIC);
     sqlite3_bind_int(stmt, 2, status);
     
     rc = sqlite3_step(stmt);

--- a/src/app/friendsbox.h
+++ b/src/app/friendsbox.h
@@ -25,6 +25,7 @@ public slots:
 
 signals:
     void friendSelected(QString friend_name);
+    void reportNewFriend(QString friend_name);
 
 private:
     QVBoxLayout *layout;

--- a/src/app/friendsbox.h
+++ b/src/app/friendsbox.h
@@ -21,6 +21,9 @@ public:
     void updateFriendStatus(const QString &username, int status);
     void addNewFriend(const QString &username, int status);
 
+signals:
+    void friendSelected(int friendId);
+
 private:
     sqlite3 *database;
     QVBoxLayout *layout;

--- a/src/app/friendsbox.h
+++ b/src/app/friendsbox.h
@@ -20,6 +20,12 @@ public:
     void handlePacket(unsigned char *packet);
     void updateFriendStatus(const QString &username, int status);
     void addNewFriend(const QString &username, int status);
+    
+    // Get selected friend information
+    int getSelectedFriendId() const;
+    QString getSelectedFriendName() const;
+    int getSelectedFriendStatus() const;
+    bool hasSelectedFriend() const;
 
 signals:
     void friendSelected(int friendId);
@@ -29,6 +35,7 @@ private:
     QVBoxLayout *layout;
     QMap<int, FriendBox*> friendWidgets;
     QMap<QString, int> friendNameToId;
+    int selectedFriendId;
     
     void loadFriends();
     void addFriend(int id, const QString &name, int status);
@@ -44,6 +51,8 @@ public:
     void handlePacket(unsigned char *packet);
     void updateStatus(int status);
     
+    QString friendName;
+    int friendStatus;
 signals:
     void friendClicked(int friendId);
 
@@ -52,8 +61,6 @@ protected:
 
 private:
     int friendId;
-    QString friendName;
-    int friendStatus;
     QLabel *statusLabel;
 };
 

--- a/src/app/friendsbox.h
+++ b/src/app/friendsbox.h
@@ -6,6 +6,7 @@
 #include <QMap>
 #include <QLabel>
 #include <sqlite3.h>
+#include <vector>
 
 class FriendBox;
 
@@ -14,16 +15,16 @@ class FriendsBox : public QWidget
     Q_OBJECT
 
 public:
-    explicit FriendsBox(sqlite3 *db, QWidget *parent = nullptr);
+    explicit FriendsBox(QWidget *parent = nullptr);
     ~FriendsBox();
 
 public slots:
     void updateFriendStatus(const QString &username, int status);
-    void addNewFriend(const QString &username, int status);
-    void processFriendList(vector<QString> friend_names);
+    void addNewFriend(int id, const QString &username, int status);
+    void processFriendList(std::vector<QString> friend_names);
 
 signals:
-    void friendSelected(int friendId);
+    void friendSelected(QString friend_name);
 
 private:
     QVBoxLayout *layout;
@@ -43,7 +44,7 @@ public:
     QString friendName;
     int friendStatus;
 signals:
-    void friendClicked(int friendId);
+    void friendClicked(QString friendName);
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;

--- a/src/app/friendsbox.h
+++ b/src/app/friendsbox.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include <QVBoxLayout>
 #include <QMap>
+#include <QLabel>
 #include <sqlite3.h>
 
 class FriendBox;
@@ -16,13 +17,19 @@ public:
     explicit FriendsBox(sqlite3 *db, QWidget *parent = nullptr);
     ~FriendsBox();
 
+    void handlePacket(unsigned char *packet);
+    void updateFriendStatus(const QString &username, int status);
+    void addNewFriend(const QString &username, int status);
+
 private:
     sqlite3 *database;
     QVBoxLayout *layout;
     QMap<int, FriendBox*> friendWidgets;
+    QMap<QString, int> friendNameToId;
     
     void loadFriends();
     void addFriend(int id, const QString &name, int status);
+    int insertFriendToDatabase(const QString &name, int status);
 };
 
 class FriendBox : public QWidget
@@ -31,6 +38,8 @@ class FriendBox : public QWidget
 
 public:
     explicit FriendBox(int friendId, const QString &name, int status, QWidget *parent = nullptr);
+    void handlePacket(unsigned char *packet);
+    void updateStatus(int status);
     
 signals:
     void friendClicked(int friendId);
@@ -42,6 +51,7 @@ private:
     int friendId;
     QString friendName;
     int friendStatus;
+    QLabel *statusLabel;
 };
 
 #endif // FRIENDSBOX_H 

--- a/src/app/friendsbox.h
+++ b/src/app/friendsbox.h
@@ -17,29 +17,19 @@ public:
     explicit FriendsBox(sqlite3 *db, QWidget *parent = nullptr);
     ~FriendsBox();
 
-    void handlePacket(unsigned char *packet);
+public slots:
     void updateFriendStatus(const QString &username, int status);
     void addNewFriend(const QString &username, int status);
-    
-    // Get selected friend information
-    int getSelectedFriendId() const;
-    QString getSelectedFriendName() const;
-    int getSelectedFriendStatus() const;
-    bool hasSelectedFriend() const;
+    void processFriendList(vector<QString> friend_names);
 
 signals:
     void friendSelected(int friendId);
 
 private:
-    sqlite3 *database;
     QVBoxLayout *layout;
     QMap<int, FriendBox*> friendWidgets;
     QMap<QString, int> friendNameToId;
     int selectedFriendId;
-    
-    void loadFriends();
-    void addFriend(int id, const QString &name, int status);
-    int insertFriendToDatabase(const QString &name, int status);
 };
 
 class FriendBox : public QWidget
@@ -48,7 +38,6 @@ class FriendBox : public QWidget
 
 public:
     explicit FriendBox(int friendId, const QString &name, int status, QWidget *parent = nullptr);
-    void handlePacket(unsigned char *packet);
     void updateStatus(int status);
     
     QString friendName;

--- a/src/app/login.cpp
+++ b/src/app/login.cpp
@@ -82,17 +82,26 @@ void LoginWidget::handlePacket(unsigned char * packet) {
     qDebug() << "Login widget received a packet";
     switch (*packet) {
         case PacketFromServerType::ACCOUNT_RESULT:
+            qDebug() << "And it's an account result packet";
             resp = new createAccountResponse(packet);
             car = dynamic_cast<createAccountResponse *>(resp);
             qDebug() << "Processing packet";
-            if (car->success) logged_in();
+            if (car->success) logged_in(usernameEdit->text());
             else message->setText(QString::fromStdString("Failed to create account: " + car->reason));
         break;
         case PacketFromServerType::LOGIN_RESULT:
+            qDebug() << "And it's a login result packet";
             resp = new loginResult(packet);
             lgr = dynamic_cast<loginResult *>(resp);
-            if (lgr->success) logged_in();
-            else message->setText(QString::fromStdString("Login failed: " + lgr->reason));
+            qDebug() << "Which it can handle perfectly well";
+            if (lgr->success) {
+                qDebug() << "By running the 'logged_in()' function";
+                logged_in(usernameEdit->text());
+            }
+            else {
+                qDebug() << "By setting the message text";
+                message->setText(QString::fromStdString("Login failed: " + lgr->reason));
+            }
         break;
         default:
         qDebug() << "Invalid packet sent to login widget";

--- a/src/app/login.cpp
+++ b/src/app/login.cpp
@@ -1,6 +1,4 @@
 #include "login.h"
-#include "packet.h"
-#include <iostream>
 #include <QWidget>
 #include <QLineEdit>
 #include <QPushButton>
@@ -10,7 +8,7 @@
 #include <QDebug>
 #include <QString>
 
-LoginWidget::LoginWidget(QWidget *parent, QTcpSocket *s) : QWidget(parent) {
+LoginWidget::LoginWidget(QWidget *parent) : QWidget(parent) {
     // Login widgets
     QVBoxLayout *loginLayout = new QVBoxLayout(this);
     QLabel *userLabel = new QLabel("Username", this);
@@ -23,7 +21,6 @@ LoginWidget::LoginWidget(QWidget *parent, QTcpSocket *s) : QWidget(parent) {
     createAccountInstead->setFlat(true);
     creating_account = false;
     message = new QLabel("", this);
-    sock = s; // do not delete if this widget is deleted
 
     // Layout is one big column for now
     loginLayout->addStretch();
@@ -61,50 +58,11 @@ void LoginWidget::swapLoginPurpose() {
 }
 
 void LoginWidget::login() {
-    if (sock->state() != QAbstractSocket::SocketState::ConnectedState) {
-        qDebug() << "Unable to log in - not connected\n";
-        return;
-    }
-    unsigned char packet[PACKET_BUFFER_SIZE];
-    packetToServer * req;
-    if (creating_account) req = new createAccountRequest(usernameEdit->text().toStdString(), passwordEdit->text().toStdString());
-    else req = new loginRequest(usernameEdit->text().toStdString(), passwordEdit->text().toStdString());    
-    req->write_to_packet(packet);
-    sock->write((char *)packet, PACKET_BUFFER_SIZE);
-    qDebug() << "Should have sent packet";
-    delete req;    
+    if (creating_account) emit requestAccount(usernameEdit->text(), passwordEdit->text());
+    else emit requestLogin(usernameEdit->text(), passwordEdit->text());
 }
 
-void LoginWidget::handlePacket(unsigned char * packet) {
-    packetFromServer * resp;
-    createAccountResponse * car = NULL;
-    loginResult * lgr = NULL;
-    qDebug() << "Login widget received a packet";
-    switch (*packet) {
-        case PacketFromServerType::ACCOUNT_RESULT:
-            qDebug() << "And it's an account result packet";
-            resp = new createAccountResponse(packet);
-            car = dynamic_cast<createAccountResponse *>(resp);
-            qDebug() << "Processing packet";
-            if (car->success) logged_in(usernameEdit->text());
-            else message->setText(QString::fromStdString("Failed to create account: " + car->reason));
-        break;
-        case PacketFromServerType::LOGIN_RESULT:
-            qDebug() << "And it's a login result packet";
-            resp = new loginResult(packet);
-            lgr = dynamic_cast<loginResult *>(resp);
-            qDebug() << "Which it can handle perfectly well";
-            if (lgr->success) {
-                qDebug() << "By running the 'logged_in()' function";
-                logged_in(usernameEdit->text());
-            }
-            else {
-                qDebug() << "By setting the message text";
-                message->setText(QString::fromStdString("Login failed: " + lgr->reason));
-            }
-        break;
-        default:
-        qDebug() << "Invalid packet sent to login widget";
-    }
-    delete resp;
+void LoginWidget::handleFailure(QString reason) {
+    if (creating_account) message->setText("Failed to create account: " + reason);
+    else message->setText("Failed to log in: " + reason);
 }

--- a/src/app/login.h
+++ b/src/app/login.h
@@ -17,7 +17,7 @@ public:
     void handlePacket(unsigned char * packet);
     QLineEdit *usernameEdit;
 signals:
-    void logged_in();
+    void logged_in(QString username);
 private slots:
     void swapLoginPurpose();
     void login();

--- a/src/app/login.h
+++ b/src/app/login.h
@@ -15,13 +15,13 @@ public:
     ~LoginWidget();
     QTcpSocket *sock;
     void handlePacket(unsigned char * packet);
+    QLineEdit *usernameEdit;
 signals:
     void logged_in();
 private slots:
     void swapLoginPurpose();
     void login();
 private:
-    QLineEdit *usernameEdit;
     QLineEdit *passwordEdit;
     QPushButton *createAccountInstead;
     bool creating_account;

--- a/src/app/login.h
+++ b/src/app/login.h
@@ -17,7 +17,7 @@ public:
 signals:
     void requestAccount(QString username, QString password);
     void requestLogin(QString username, QString password);
-slots:
+public slots:
     void handleFailure(QString reason);
 private slots:
     void swapLoginPurpose();

--- a/src/app/login.h
+++ b/src/app/login.h
@@ -11,17 +11,19 @@ class LoginWidget : public QWidget {
     Q_OBJECT
 
 public:
-    explicit LoginWidget(QWidget *parent = nullptr, QTcpSocket * s = nullptr);
+    explicit LoginWidget(QWidget *parent = nullptr);
     ~LoginWidget();
-    QTcpSocket *sock;
     void handlePacket(unsigned char * packet);
-    QLineEdit *usernameEdit;
 signals:
-    void logged_in(QString username);
+    void requestAccount(QString username, QString password);
+    void requestLogin(QString username, QString password);
+slots:
+    void handleFailure(QString reason);
 private slots:
     void swapLoginPurpose();
     void login();
 private:
+    QLineEdit *usernameEdit;
     QLineEdit *passwordEdit;
     QPushButton *createAccountInstead;
     bool creating_account;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -16,84 +16,14 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // Create friends table if it doesn't exist
-    const char *create_friends_table = R"(
-        CREATE TABLE IF NOT EXISTS friends (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            friend_name TEXT NOT NULL,
-            status INTEGER NOT NULL
-        )
-    )";
-    
-    rc = sqlite3_exec(db, create_friends_table, nullptr, nullptr, nullptr);
-    if (rc != SQLITE_OK) {
-        std::cerr << "SQL error creating friends table: " << sqlite3_errmsg(db) << std::endl;
+    // Set up database if it doesn't exist    
+    if (sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS friends (id INTEGER PRIMARY KEY AUTOINCREMENT, friend_name TEXT NOT NULL, status INTEGER NOT NULL)", nullptr, nullptr, nullptr) ||
+        sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, friend_id INTEGER NOT NULL, message TEXT NOT NULL, original BOOLEAN NOT NULL, FOREIGN KEY (friend_id) REFERENCES friends (id))", nullptr, nullptr, nullptr) ||
+        sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS requests (friend_name TEXT NOT NULL, status INTEGER NOT NULL)", nullptr, nullptr, nullptr)) {
+        std::cerr << "SQL error creating tables: " << sqlite3_errmsg(db) << std::endl;
         sqlite3_close(db);
         return 1;
     }
-
-    // Create messages table if it doesn't exist
-    const char *create_messages_table = R"(
-        CREATE TABLE IF NOT EXISTS messages (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            message TEXT NOT NULL,
-            friend_id INTEGER NOT NULL,
-            original BOOLEAN NOT NULL,
-            FOREIGN KEY (friend_id) REFERENCES friends (id)
-        )
-    )";
-    
-    rc = sqlite3_exec(db, create_messages_table, nullptr, nullptr, nullptr);
-    if (rc != SQLITE_OK) {
-        std::cerr << "SQL error creating messages table: " << sqlite3_errmsg(db) << std::endl;
-        sqlite3_close(db);
-        return 1;
-    }
-
-    // Check if friends table is empty and insert sample data
-    sqlite3_stmt *stmt;
-    rc = sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM friends", -1, &stmt, nullptr);
-    if (rc == SQLITE_OK) {
-        if (sqlite3_step(stmt) == SQLITE_ROW) {
-            int count = sqlite3_column_int(stmt, 0);
-            if (count == 0) {
-                // Insert sample friends
-                const char *insert_friends[] = {
-                    "INSERT INTO friends (friend_name, status) VALUES ('Alice', 1)",
-                    "INSERT INTO friends (friend_name, status) VALUES ('Bob', 2)",
-                    "INSERT INTO friends (friend_name, status) VALUES ('Charlie', 1)",
-                    "INSERT INTO friends (friend_name, status) VALUES ('Diana', 2)",
-                    "INSERT INTO friends (friend_name, status) VALUES ('Eve', 1)"
-                };
-                
-                for (const char *sql : insert_friends) {
-                    rc = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
-                    if (rc != SQLITE_OK) {
-                        std::cerr << "SQL error inserting friend: " << sqlite3_errmsg(db) << std::endl;
-                    }
-                }
-                
-                // Insert sample messages
-                const char *insert_messages[] = {
-                    "INSERT INTO messages (message, friend_id, original) VALUES ('Hey Alice!', 1, 1)",
-                    "INSERT INTO messages (message, friend_id, original) VALUES ('How are you?', 1, 0)",
-                    "INSERT INTO messages (message, friend_id, original) VALUES ('Hi Bob', 2, 1)",
-                    "INSERT INTO messages (message, friend_id, original) VALUES ('Good morning Charlie', 3, 1)",
-                    "INSERT INTO messages (message, friend_id, original) VALUES ('See you later!', 3, 0)"
-                };
-                
-                for (const char *sql : insert_messages) {
-                    rc = sqlite3_exec(db, sql, nullptr, nullptr, nullptr);
-                    if (rc != SQLITE_OK) {
-                        std::cerr << "SQL error inserting message: " << sqlite3_errmsg(db) << std::endl;
-                    }
-                }
-                
-                std::cout << "Inserted sample data into database" << std::endl;
-            }
-        }
-    }
-    sqlite3_finalize(stmt);
 
     MainWindow window(db);
     window.show();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,4 +1,6 @@
 #include <QApplication>
+#include "clientsocket.h"
+#include "database.h"
 #include "mainwindow.h"
 #include "packet.h"
 #include <sqlite3.h>
@@ -8,37 +10,22 @@ int main(int argc, char **argv)
 {
     QApplication app(argc, argv);
 
-    ClientSocketManager sock();
-    ClientDatabaseManager db();
-    MainWindow window();
+    // Get server address if one is present in command-line arguments
+    QString server_address = "127.0.0.1";
+    int i = 1;
+    while (i < argc) {
+        if (!strcmp(argv[i], "-ip")) {
+            ++i;
+            if (i == argc) {
+                std::cerr << "No IP address after -ip flag\n";
+                return 1;
+            }
+            server_address = QString(argv[i]);
+        }
+        ++i;
+    }
 
-    connect(sock, &ClientSocketManager::mentionLoginSuccess, window, &MainWindow::showMainCentralWidget);
-    connect(sock, &ClientSocketManager::mentionAccountResult, window->loginWidget, &LoginWidget::handleFailure);
-    connect(sock, &ClientSocketManager::mentionLoginResult, window->loginWidget, &LoginWidget::handleFailure);
-    
-    connect(window->loginWidget, &LoginWidget::requestAccount, sock, &ClientSocketManager::sendAccountRequest);
-    connect(window->loginWidget, &LoginWidget::requestLogin, sock, &ClientSocketManager::sendLoginRequest);
-
-    connect(sock, &ClientSocketManager::mentionLoginSuccess, db, &ClientDatabaseManager::queryFriends);
-    connect(db, &ClientDatabaseManager::outputFriendList, window->friendsBox, &FriendsBox::processFriendList);
-    
-    connect(sock, &ClientSocketManager::mentionFriendStatus, window->friendsBox, &FriendsBox::updateFriendStatus);
-    connect(window->requestsBox, &RequestsBox::requestFriendRequest, sock, &ClientSocketManager::sendFriendRequest);
-    connect(window->requestsBox, &RequestsBox::requestFriendResponse, sock, &ClientSocketManager::sendFriendRequest);
-    connect(sock, &ClientSocketManager::mentionFriendRequest, window->requestsBox, &RequestsBox::processFriendRequest);
-    connect(sock, &ClientSocketManager::mentionFriendRequestResponse, window->requestsBox, &RequestsBox::processFriendResponse);
-    connect(window->requestsBox, &RequestsBox::announceNewFriend, window->friendsBox, &FriendsBox::addNewFriend);
-
-    connect(sock, &ClientSocketManager::mentionMessage, window->codeBox, &CodeBox::decryptAndReceiveMessage);
-    connect(window->codeBox, &CodeBox::requestMessageSend, sock, &ClientSocketManager::sendMessage);
-
-    connect(db, &ClientDatabaseManager::outputMessageQuery, window->messagesBox, &MessagesBox::processMessages);
-    connect(window->codeBox, &CodeBox::reportDecryptedMessage, db, &ClientDatabaseManager::insertMessage);
-    connect(db, &ClientDatabaseManager::reportIncomingMessage, window->messagesBox, &MessagesBox::addMessage);
-    connect(window->friendsBox, &FriendsBox::friendSelected, db, &ClientDatabaseManager::queryMessages);
-
-    connect(window->sendButton, &QPushButton::clicked, app, [db, window](){ db->insertMessage(window->rightTextBox->text(), true); } );
-    connect(db, &ClientDatabaseManager::reportOutgoingMessage, window->codeBox, &CodeBox::encryptAndSendMessage);
+    MainWindow window(server_address);
 
     window.show();
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -18,8 +18,7 @@ int main(int argc, char **argv)
 
     // Set up database if it doesn't exist    
     if (sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS friends (id INTEGER PRIMARY KEY AUTOINCREMENT, friend_name TEXT NOT NULL, status INTEGER NOT NULL)", nullptr, nullptr, nullptr) ||
-        sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, friend_id INTEGER NOT NULL, message TEXT NOT NULL, original BOOLEAN NOT NULL, FOREIGN KEY (friend_id) REFERENCES friends (id))", nullptr, nullptr, nullptr) ||
-        sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS requests (friend_name TEXT NOT NULL, status INTEGER NOT NULL)", nullptr, nullptr, nullptr)) {
+        sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, friend_id INTEGER NOT NULL, message TEXT NOT NULL, original BOOLEAN NOT NULL, FOREIGN KEY (friend_id) REFERENCES friends (id))", nullptr, nullptr, nullptr)) {
         std::cerr << "SQL error creating tables: " << sqlite3_errmsg(db) << std::endl;
         sqlite3_close(db);
         return 1;

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -69,9 +69,10 @@ void MainWindow::showMainCentralWidget()
     rightFrame = new QFrame(mainCentralWidget);
     rightFrame->setFrameShape(QFrame::StyledPanel);
     QVBoxLayout *rightLayout = new QVBoxLayout(rightFrame);
-    rightEmptyFrame = new QFrame(rightFrame);
-    rightEmptyFrame->setFrameShape(QFrame::NoFrame);
-    rightLayout->addWidget(rightEmptyFrame);
+    
+    // Create MessagesBox to replace the empty frame
+    messagesBox = new MessagesBox(database, rightFrame);
+    rightLayout->addWidget(messagesBox);
     QHBoxLayout *bottomRow = new QHBoxLayout();
     rightTextBox = new QLineEdit(rightFrame);
     bottomRow->addWidget(rightTextBox);
@@ -87,6 +88,9 @@ void MainWindow::showMainCentralWidget()
     mainLayout->setStretch(0, 0);
     mainLayout->setStretch(1, 1);
     setCentralWidget(mainCentralWidget);
+    
+    // Connect friend selection to messages box
+    connect(friendsBox, &FriendsBox::friendSelected, messagesBox, &MessagesBox::selectFriend);
 }
 
 void MainWindow::handlePacket() {

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -15,6 +15,8 @@
 MainWindow::MainWindow(sqlite3 *db, QWidget *parent)
     : QMainWindow(parent), database(db)
 {
+
+    // Set up connection to server
     sock = new QTcpSocket();
     QAbstractSocket::SocketState s = sock->state();
     qDebug() << "About to attempt to connect";
@@ -24,19 +26,11 @@ MainWindow::MainWindow(sqlite3 *db, QWidget *parent)
     else {
         qDebug() << "Failed to connect to server\n";
     }
-    showLoginWidget();
-    connect(sock, &QTcpSocket::readyRead, this, &MainWindow::handlePacket);
-}
 
-void MainWindow::showLoginWidget()
-{
+    // Login widget takes up the entire screen
     loginWidget = new LoginWidget(this, sock);
-    setCentralWidget(loginWidget);
     connect(loginWidget, &LoginWidget::logged_in, this, &MainWindow::showMainCentralWidget);
-}
 
-void MainWindow::showMainCentralWidget()
-{
     mainCentralWidget = new QWidget(this);
     QHBoxLayout *mainLayout = new QHBoxLayout(mainCentralWidget);
     // Left frame
@@ -87,10 +81,21 @@ void MainWindow::showMainCentralWidget()
     mainLayout->addWidget(rightFrame);
     mainLayout->setStretch(0, 0);
     mainLayout->setStretch(1, 1);
-    setCentralWidget(mainCentralWidget);
-    
     // Connect friend selection to messages box
     connect(friendsBox, &FriendsBox::friendSelected, messagesBox, &MessagesBox::selectFriend);
+
+    showLoginWidget();
+    connect(sock, &QTcpSocket::readyRead, this, &MainWindow::handlePacket);
+}
+
+void MainWindow::showLoginWidget()
+{
+    setCentralWidget(loginWidget);
+}
+
+void MainWindow::showMainCentralWidget()
+{
+    setCentralWidget(mainCentralWidget);
 }
 
 void MainWindow::handlePacket() {

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -103,6 +103,7 @@ MainWindow::MainWindow(QString server_address, QWidget *parent)
     connect(sock, &ClientSocketManager::mentionFriendResponse, requestsBox, &RequestsBox::processFriendResponse);
     connect(requestsBox, &RequestsBox::announceNewFriend, db, &ClientDatabaseManager::insertFriend);
     connect(db, &ClientDatabaseManager::reportNewFriend, friendsBox, &FriendsBox::addNewFriend);
+    connect(friendsBox, &FriendsBox::reportNewFriend, db, &ClientDatabaseManager::insertFriend);
 
     connect(sock, &ClientSocketManager::mentionMessage, codeBox, &CodeBox::decryptAndReceiveMessage);
     connect(codeBox, &CodeBox::requestMessageSend, sock, &ClientSocketManager::sendMessage);

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -95,6 +95,7 @@ void MainWindow::showLoginWidget()
 
 void MainWindow::showMainCentralWidget()
 {
+    requestsBox->my_name = loginWidget->usernameEdit->text();
     setCentralWidget(mainCentralWidget);
 }
 

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -46,12 +46,16 @@ MainWindow::MainWindow(sqlite3 *db, QWidget *parent)
     leftLayout->addWidget(requestsBox);
     
     leftLayout->addSpacing(10);
+
+    // To be replaced by CodeBox:
     codebookLabel = new QLabel("Codebook: NONE", leftFrame);
     codebookLabel->setFixedHeight(30);
     leftLayout->addWidget(codebookLabel);
     viewCodebooksButton = new QPushButton("View codebooks", leftFrame);
     viewCodebooksButton->setFixedHeight(30);
     leftLayout->addWidget(viewCodebooksButton);
+
+
     leftLayout->setStretch(0, 1);
     leftLayout->setStretch(1, 0);
     leftLayout->setStretch(2, 0);

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -29,7 +29,6 @@ MainWindow::MainWindow(sqlite3 *db, QWidget *parent)
 
     // Login widget takes up the entire screen
     loginWidget = new LoginWidget(this, sock);
-    connect(loginWidget, &LoginWidget::logged_in, this, &MainWindow::showMainCentralWidget);
 
     mainCentralWidget = new QWidget(this);
     QHBoxLayout *mainLayout = new QHBoxLayout(mainCentralWidget);
@@ -85,6 +84,7 @@ MainWindow::MainWindow(sqlite3 *db, QWidget *parent)
     connect(friendsBox, &FriendsBox::friendSelected, messagesBox, &MessagesBox::selectFriend);
 
     showLoginWidget();
+    connect(loginWidget, &LoginWidget::logged_in, this, &MainWindow::showMainCentralWidget);
     connect(sock, &QTcpSocket::readyRead, this, &MainWindow::handlePacket);
 }
 
@@ -93,10 +93,13 @@ void MainWindow::showLoginWidget()
     setCentralWidget(loginWidget);
 }
 
-void MainWindow::showMainCentralWidget()
+void MainWindow::showMainCentralWidget(QString new_username)
 {
-    requestsBox->my_name = loginWidget->usernameEdit->text();
+    qDebug() << "Should be showing the main central widget now";
+    requestsBox->my_name = new_username;
+    qDebug() << "Successfully set a name property";
     setCentralWidget(mainCentralWidget);
+    qDebug() << "And the central widget";
 }
 
 void MainWindow::handlePacket() {
@@ -109,15 +112,20 @@ void MainWindow::handlePacket() {
     else {
         switch (*packet) {
             case PacketFromServerType::ACCOUNT_RESULT:
+                qDebug() << "It's an account result packet";
             case PacketFromServerType::LOGIN_RESULT:
+                qDebug() << "It's a login result packet";
                 loginWidget->handlePacket(packet);
                 break;
             case PacketFromServerType::FRIEND_STATUS_UPDATE:
+                qDebug() << "It's a friend status update packet";
                 friendsBox->handlePacket(packet);
             case PacketFromServerType::FRIEND_REQUEST_RESPONSE:
+                qDebug() << "It's a friend request response packet";
                 requestsBox->handlePacket(packet);
                 break;
             case PacketFromServerType::FRIEND_REQUEST_FORWARD:
+                qDebug() << "It's a friend request forwarding packet";
                 requestsBox->handlePacket(packet);
                 break;
             default:

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -98,9 +98,9 @@ MainWindow::MainWindow(QString server_address, QWidget *parent)
     
     connect(sock, &ClientSocketManager::mentionFriendStatus, friendsBox, &FriendsBox::updateFriendStatus);
     connect(requestsBox, &RequestsBox::requestFriendRequest, sock, &ClientSocketManager::sendFriendRequest);
-    connect(requestsBox, &RequestsBox::requestFriendResponse, sock, &ClientSocketManager::sendFriendRequest);
+    connect(requestsBox, &RequestsBox::requestFriendResponse, sock, &ClientSocketManager::sendFriendResponse);
     connect(sock, &ClientSocketManager::mentionFriendRequest, requestsBox, &RequestsBox::processFriendRequest);
-    connect(sock, &ClientSocketManager::mentionFriendRequestResponse, requestsBox, &RequestsBox::processFriendResponse);
+    connect(sock, &ClientSocketManager::mentionFriendResponse, requestsBox, &RequestsBox::processFriendResponse);
     connect(requestsBox, &RequestsBox::announceNewFriend, db, &ClientDatabaseManager::insertFriend);
     connect(db, &ClientDatabaseManager::reportNewFriend, friendsBox, &FriendsBox::addNewFriend);
 

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -13,23 +13,11 @@
 #include <QSpacerItem>
 #include <QTcpSocket>
 
-MainWindow::MainWindow(sqlite3 *db, QWidget *parent)
-    : QMainWindow(parent), database(db)
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
 {
-
-    // Set up connection to server
-    sock = new QTcpSocket();
-    QAbstractSocket::SocketState s = sock->state();
-    qDebug() << "About to attempt to connect";
-    sock->connectToHost("127.0.0.1", 1999);
-    if (sock->waitForConnected(3000))
-        qDebug() << "Connected to server!\n";
-    else {
-        qDebug() << "Failed to connect to server\n";
-    }
-
     // Login widget takes up the entire screen
-    loginWidget = new LoginWidget(this, sock);
+    loginWidget = new LoginWidget(this);
 
     mainCentralWidget = new QWidget(this);
     QHBoxLayout *mainLayout = new QHBoxLayout(mainCentralWidget);
@@ -88,8 +76,6 @@ MainWindow::MainWindow(sqlite3 *db, QWidget *parent)
     connect(sendButton, &QPushButton::clicked, this, &MainWindow::onSendButtonClicked);
 
     showLoginWidget();
-    connect(loginWidget, &LoginWidget::logged_in, this, &MainWindow::showMainCentralWidget);
-    connect(sock, &QTcpSocket::readyRead, this, &MainWindow::handlePacket);
 }
 
 void MainWindow::showLoginWidget()

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -44,8 +44,14 @@ void MainWindow::showMainCentralWidget()
     leftFrame->setFrameShape(QFrame::StyledPanel);
     leftFrame->setFixedWidth(200);
     QVBoxLayout *leftLayout = new QVBoxLayout(leftFrame);
+    
+    // Add FriendsBox and RequestsBox
     friendsBox = new FriendsBox(database, leftFrame);
     leftLayout->addWidget(friendsBox);
+    
+    requestsBox = new RequestsBox(database, sock, leftFrame);
+    leftLayout->addWidget(requestsBox);
+    
     leftLayout->addSpacing(10);
     codebookLabel = new QLabel("Codebook: NONE", leftFrame);
     codebookLabel->setFixedHeight(30);
@@ -57,6 +63,8 @@ void MainWindow::showMainCentralWidget()
     leftLayout->setStretch(1, 0);
     leftLayout->setStretch(2, 0);
     leftLayout->setStretch(3, 0);
+    leftLayout->setStretch(4, 0);
+
     // Right frame
     rightFrame = new QFrame(mainCentralWidget);
     rightFrame->setFrameShape(QFrame::StyledPanel);
@@ -92,13 +100,20 @@ void MainWindow::handlePacket() {
         switch (*packet) {
             case PacketFromServerType::ACCOUNT_RESULT:
             case PacketFromServerType::LOGIN_RESULT:
-            loginWidget->handlePacket(packet);
-            break;
+                loginWidget->handlePacket(packet);
+                break;
+            case PacketFromServerType::FRIEND_STATUS_UPDATE:
+                friendsBox->handlePacket(packet);
+            case PacketFromServerType::FRIEND_REQUEST_RESPONSE:
+                requestsBox->handlePacket(packet);
+                break;
+            case PacketFromServerType::FRIEND_REQUEST_FORWARD:
+                requestsBox->handlePacket(packet);
+                break;
             default:
-            qDebug() << "Received invalid packet";
+                qDebug() << "Received invalid packet";
         }
     }
-
 }
 
 MainWindow::~MainWindow()

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -4,6 +4,7 @@
 #include "login.h"
 #include "friendsbox.h"
 #include "requestsbox.h"
+#include "messagesbox.h"
 #include <QMainWindow>
 #include <QWidget>
 #include <QLineEdit>
@@ -32,6 +33,7 @@ private:
     QFrame *rightFrame;
     FriendsBox * friendsBox;
     RequestsBox *requestsBox;
+    MessagesBox *messagesBox;
     QLabel *codebookLabel;
     QPushButton *viewCodebooksButton;
     QFrame *rightEmptyFrame;

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -11,6 +11,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QFrame>
+#include <QString>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <sqlite3.h>
@@ -44,7 +45,7 @@ private:
     sqlite3 *database;
 
     void showLoginWidget();
-    void showMainCentralWidget();
+    void showMainCentralWidget(QString);
     void handlePacket();
 };
 

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -5,6 +5,7 @@
 #include "friendsbox.h"
 #include "requestsbox.h"
 #include "messagesbox.h"
+#include "codebox.h"
 #include <QMainWindow>
 #include <QWidget>
 #include <QLineEdit>
@@ -35,8 +36,7 @@ private:
     FriendsBox * friendsBox;
     RequestsBox *requestsBox;
     MessagesBox *messagesBox;
-    QLabel *codebookLabel;
-    QPushButton *viewCodebooksButton;
+    CodeBox *codeBox;
     QFrame *rightEmptyFrame;
     QLineEdit *rightTextBox;
     QPushButton *sendButton;
@@ -47,6 +47,9 @@ private:
     void showLoginWidget();
     void showMainCentralWidget(QString);
     void handlePacket();
+    
+private slots:
+    void onSendButtonClicked();
 };
 
 #endif

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -5,6 +5,8 @@
 #include "friendsbox.h"
 #include "requestsbox.h"
 #include "messagesbox.h"
+#include "clientsocket.h"
+#include "database.h"
 #include "codebox.h"
 #include <QMainWindow>
 #include <QWidget>
@@ -22,14 +24,13 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow(sqlite3 *db, QWidget *parent = nullptr);
+    explicit MainWindow(QString server_address, QWidget *parent = nullptr);
     ~MainWindow();
 
-    LoginWidget *loginWidget;
-private:
-    // Login screen widgets
+    void showMainCentralWidget();
+    void showLoginWidget();
 
-    // Main central widget and its components
+    LoginWidget *loginWidget;
     QWidget *mainCentralWidget;
     QFrame *leftFrame;
     QFrame *rightFrame;
@@ -41,12 +42,8 @@ private:
     QLineEdit *rightTextBox;
     QPushButton *sendButton;
 
-    void showLoginWidget();
-    void showMainCentralWidget(QString);
-    void handlePacket();
-    
-private slots:
-    void onSendButtonClicked();
+    ClientSocketManager * sock;
+    ClientDatabaseManager * db;
 };
 
 #endif

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include "login.h"
 #include "friendsbox.h"
+#include "requestsbox.h"
 #include <QMainWindow>
 #include <QWidget>
 #include <QLineEdit>
@@ -30,6 +31,7 @@ private:
     QFrame *leftFrame;
     QFrame *rightFrame;
     FriendsBox * friendsBox;
+    RequestsBox *requestsBox;
     QLabel *codebookLabel;
     QPushButton *viewCodebooksButton;
     QFrame *rightEmptyFrame;

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -25,9 +25,9 @@ public:
     explicit MainWindow(sqlite3 *db, QWidget *parent = nullptr);
     ~MainWindow();
 
+    LoginWidget *loginWidget;
 private:
     // Login screen widgets
-    LoginWidget *loginWidget;
 
     // Main central widget and its components
     QWidget *mainCentralWidget;
@@ -40,9 +40,6 @@ private:
     QFrame *rightEmptyFrame;
     QLineEdit *rightTextBox;
     QPushButton *sendButton;
-
-    QTcpSocket *sock;
-    sqlite3 *database;
 
     void showLoginWidget();
     void showMainCentralWidget(QString);

--- a/src/app/messagesbox.cpp
+++ b/src/app/messagesbox.cpp
@@ -7,9 +7,11 @@
 #include <QSpacerItem>
 #include <QTimer>
 #include <QScrollBar>
+#include <vector>
+#include <tuple>
 
-MessagesBox::MessagesBox(sqlite3 *db, QWidget *parent)
-    : QWidget(parent), database(db), currentFriendId(-1)
+MessagesBox::MessagesBox(QWidget *parent)
+    : QWidget(parent)
 {
     layout = new QVBoxLayout(this);
     layout->setContentsMargins(5, 5, 5, 5);
@@ -46,27 +48,11 @@ MessagesBox::~MessagesBox()
     // Qt will delete child widgets automatically
 }
 
-void MessagesBox::selectFriend(int friendId)
-{
-    if (friendId == currentFriendId) {
-        return; // Already showing this friend's messages
-    }
-    
-    currentFriendId = friendId;
-    loadMessages(friendId);
-}
-
-void MessagesBox::processMessages(vector<tuple<QString, bool>> messages, int id)
+void MessagesBox::processMessages(std::vector<std::tuple<QString, bool>> messages, int id)
 {
     clearMessages();
 
     currentMinMessageId = id;
-    
-    if (friendId <= 0) {
-        scrollArea->hide();
-        noSelectionLabel->show();
-        return;
-    }
     
     bool hasMessages = messages.size();
     
@@ -75,8 +61,8 @@ void MessagesBox::processMessages(vector<tuple<QString, bool>> messages, int id)
         scrollArea->show();
         noSelectionLabel->hide();
 
-        for (&message : messages) {
-            addMessage(get<0>message, get<1>message);
+        for (auto message : messages) {
+            addMessage(std::get<0>(message), std::get<1>(message));
         }
         
         // Scroll to the bottom to show latest messages

--- a/src/app/messagesbox.cpp
+++ b/src/app/messagesbox.cpp
@@ -1,0 +1,166 @@
+#include "messagesbox.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QScrollArea>
+#include <QLabel>
+#include <QDebug>
+#include <QSpacerItem>
+#include <QTimer>
+#include <QScrollBar>
+
+MessagesBox::MessagesBox(sqlite3 *db, QWidget *parent)
+    : QWidget(parent), database(db), currentFriendId(-1)
+{
+    layout = new QVBoxLayout(this);
+    layout->setContentsMargins(5, 5, 5, 5);
+    layout->setSpacing(5);
+    
+    // Create scroll area for messages
+    scrollArea = new QScrollArea(this);
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    
+    // Create content widget for scroll area
+    scrollContent = new QWidget(scrollArea);
+    scrollContent->setLayout(new QVBoxLayout(scrollContent));
+    scrollContent->layout()->setSpacing(5);
+    scrollContent->layout()->setContentsMargins(5, 5, 5, 5);
+    
+    scrollArea->setWidget(scrollContent);
+    layout->addWidget(scrollArea);
+    
+    // Create "no selection" label
+    noSelectionLabel = new QLabel("Select a friend to view messages", this);
+    noSelectionLabel->setAlignment(Qt::AlignCenter);
+    noSelectionLabel->setStyleSheet("color: #666; font-size: 14px;");
+    layout->addWidget(noSelectionLabel);
+    
+    // Initially show the no selection label
+    scrollArea->hide();
+    noSelectionLabel->show();
+}
+
+MessagesBox::~MessagesBox()
+{
+    // Qt will delete child widgets automatically
+}
+
+void MessagesBox::selectFriend(int friendId)
+{
+    if (friendId == currentFriendId) {
+        return; // Already showing this friend's messages
+    }
+    
+    currentFriendId = friendId;
+    loadMessages(friendId);
+}
+
+void MessagesBox::loadMessages(int friendId)
+{
+    clearMessages();
+    
+    if (friendId <= 0) {
+        scrollArea->hide();
+        noSelectionLabel->show();
+        return;
+    }
+    
+    // Get friend name for display
+    QString friendName;
+    const char *nameSql = "SELECT friend_name FROM friends WHERE id = ?";
+    sqlite3_stmt *nameStmt;
+    int rc = sqlite3_prepare_v2(database, nameSql, -1, &nameStmt, nullptr);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_int(nameStmt, 1, friendId);
+        if (sqlite3_step(nameStmt) == SQLITE_ROW) {
+            friendName = QString::fromUtf8((const char*)sqlite3_column_text(nameStmt, 0));
+        }
+    }
+    sqlite3_finalize(nameStmt);
+    
+    // Load messages for this friend
+    const char *sql = "SELECT message, original FROM messages WHERE friend_id = ? ORDER BY id";
+    sqlite3_stmt *stmt;
+    
+    rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+        qDebug() << "Failed to prepare statement:" << sqlite3_errmsg(database);
+        return;
+    }
+    
+    sqlite3_bind_int(stmt, 1, friendId);
+    
+    bool hasMessages = false;
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *message = (const char*)sqlite3_column_text(stmt, 0);
+        bool isOriginal = sqlite3_column_int(stmt, 1) != 0;
+        
+        MessageBox *messageBox = new MessageBox(QString::fromUtf8(message), isOriginal, scrollContent);
+        scrollContent->layout()->addWidget(messageBox);
+        hasMessages = true;
+    }
+    
+    sqlite3_finalize(stmt);
+    
+    if (hasMessages) {
+        // Show scroll area and hide no selection label
+        scrollArea->show();
+        noSelectionLabel->hide();
+        
+        // Scroll to the bottom to show latest messages
+        QTimer::singleShot(100, [this]() {
+            QScrollBar *scrollBar = scrollArea->verticalScrollBar();
+            scrollBar->setValue(scrollBar->maximum());
+        });
+    } else {
+        // Show "no messages" label
+        QLabel *noMessagesLabel = new QLabel("No messages yet", scrollContent);
+        noMessagesLabel->setAlignment(Qt::AlignCenter);
+        noMessagesLabel->setStyleSheet("color: #666; font-size: 14px;");
+        scrollContent->layout()->addWidget(noMessagesLabel);
+        
+        scrollArea->show();
+        noSelectionLabel->hide();
+    }
+}
+
+void MessagesBox::clearMessages()
+{
+    // Remove all child widgets from scroll content
+    QLayout *contentLayout = scrollContent->layout();
+    QLayoutItem *item;
+    while ((item = contentLayout->takeAt(0)) != nullptr) {
+        delete item->widget();
+        delete item;
+    }
+}
+
+MessageBox::MessageBox(const QString &message, bool isOriginal, QWidget *parent)
+    : QWidget(parent), messageText(message), isOriginalMessage(isOriginal)
+{
+    setFixedHeight(60);
+    
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->setContentsMargins(10, 5, 10, 5);
+    
+    // Create message label
+    messageLabel = new QLabel(message, this);
+    messageLabel->setWordWrap(true);
+    messageLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    
+    // Style based on whether it's original or received
+    if (isOriginal) {
+        // Original message (sent by user) - align to right, blue background
+        layout->addStretch();
+        layout->addWidget(messageLabel);
+        setStyleSheet("QWidget { background-color: #007AFF; border-radius: 10px; }");
+        messageLabel->setStyleSheet("color: white; font-size: 12px; padding: 5px;");
+    } else {
+        // Received message - align to left, gray background
+        layout->addWidget(messageLabel);
+        layout->addStretch();
+        setStyleSheet("QWidget { background-color: #E5E5EA; border-radius: 10px; }");
+        messageLabel->setStyleSheet("color: black; font-size: 12px; padding: 5px;");
+    }
+} 

--- a/src/app/messagesbox.h
+++ b/src/app/messagesbox.h
@@ -6,6 +6,8 @@
 #include <QScrollArea>
 #include <QLabel>
 #include <sqlite3.h>
+#include <vector>
+#include <tuple>
 
 class MessageBox;
 
@@ -18,8 +20,8 @@ public:
     ~MessagesBox();
 
 public slots:
-    void processMessages(vector<tuple<QString, bool>> messages, int id);
-    void addMessage(QString message, bool original, QString friend);
+    void processMessages(std::vector<std::tuple<QString, bool>> messages, int id);
+    void addMessage(QString message, bool original);
 
 private:
     QVBoxLayout *layout;

--- a/src/app/messagesbox.h
+++ b/src/app/messagesbox.h
@@ -14,20 +14,20 @@ class MessagesBox : public QWidget
     Q_OBJECT
 
 public:
-    explicit MessagesBox(sqlite3 *db, QWidget *parent = nullptr);
+    explicit MessagesBox(QWidget *parent = nullptr);
     ~MessagesBox();
 
-    void selectFriend(int friendId);
+public slots:
+    void processMessages(vector<tuple<QString, bool>> messages, int id);
+    void addMessage(QString message, bool original, QString friend);
 
 private:
-    sqlite3 *database;
     QVBoxLayout *layout;
     QScrollArea *scrollArea;
     QWidget *scrollContent;
     QLabel *noSelectionLabel;
-    int currentFriendId;
+    int currentMinMessageId;
     
-    void loadMessages(int friendId);
     void clearMessages();
 };
 

--- a/src/app/messagesbox.h
+++ b/src/app/messagesbox.h
@@ -1,0 +1,47 @@
+#ifndef MESSAGESBOX_H
+#define MESSAGESBOX_H
+
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QScrollArea>
+#include <QLabel>
+#include <sqlite3.h>
+
+class MessageBox;
+
+class MessagesBox : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit MessagesBox(sqlite3 *db, QWidget *parent = nullptr);
+    ~MessagesBox();
+
+    void selectFriend(int friendId);
+
+private:
+    sqlite3 *database;
+    QVBoxLayout *layout;
+    QScrollArea *scrollArea;
+    QWidget *scrollContent;
+    QLabel *noSelectionLabel;
+    int currentFriendId;
+    
+    void loadMessages(int friendId);
+    void clearMessages();
+};
+
+class MessageBox : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit MessageBox(const QString &message, bool isOriginal, QWidget *parent = nullptr);
+
+private:
+    QString messageText;
+    bool isOriginalMessage;
+    QLabel *messageLabel;
+};
+
+#endif // MESSAGESBOX_H 

--- a/src/app/requestsbox.cpp
+++ b/src/app/requestsbox.cpp
@@ -53,10 +53,12 @@ void RequestsBox::handlePacket(unsigned char *packet)
                     msgBox.exec();
                 break;
                 case FriendRequestResponse::PENDING:
+                qDebug() << "Adding request from " << response.to;
                     addRequest(QString::fromStdString(response.to), false);
                 break;
                 case FriendRequestResponse::ACCEPT:
                 case FriendRequestResponse::REJECT:
+                qDebug() << "Removing request from " << response.to;
                     removeRequest(QString::fromStdString(response.to));
                     break;
             }
@@ -76,7 +78,7 @@ void RequestsBox::addRequest(const QString &from, bool hasButtons)
     layout->insertWidget(layout->count() - 1, requestBox); // Insert before the button
     
     connect(requestBox, &RequestBox::acceptRequest, this, [this](const QString &username) {
-        sendFriendRequestAcknowledge("", username, FriendRequestResponse::ACCEPT);
+        sendFriendRequestAcknowledge(my_name, username, FriendRequestResponse::ACCEPT);
         // Add friend to database
         const char *sql = "INSERT INTO friends (friend_name, status) VALUES (?, ?)";
         sqlite3_stmt *stmt;
@@ -91,12 +93,12 @@ void RequestsBox::addRequest(const QString &from, bool hasButtons)
     });
     
     connect(requestBox, &RequestBox::rejectRequest, this, [this](const QString &username) {
-        sendFriendRequestAcknowledge("", username, FriendRequestResponse::REJECT);
+        sendFriendRequestAcknowledge(my_name, username, FriendRequestResponse::REJECT);
         removeRequest(username);
     });
     
     connect(requestBox, &RequestBox::hideRequest, this, [this](const QString &username) {
-        sendFriendRequestAcknowledge("", username, FriendRequestResponse::HIDE);
+        sendFriendRequestAcknowledge(my_name, username, FriendRequestResponse::HIDE);
         removeRequest(username);
     });
 }

--- a/src/app/requestsbox.cpp
+++ b/src/app/requestsbox.cpp
@@ -1,0 +1,244 @@
+#include "requestsbox.h"
+#include "packet.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QDialog>
+#include <QLineEdit>
+#include <QDialogButtonBox>
+#include <QMessageBox>
+#include <QDebug>
+#include <QTcpSocket>
+
+RequestsBox::RequestsBox(sqlite3 *db, QTcpSocket *socket, QWidget *parent)
+    : QWidget(parent), database(db), socket(socket)
+{
+    layout = new QVBoxLayout(this);
+    layout->setSpacing(5);
+    layout->setContentsMargins(5, 5, 5, 5);
+    
+    // Add "Create Friend Request" button at the bottom
+    QPushButton *createRequestButton = new QPushButton("Create Friend Request", this);
+    createRequestButton->setFixedHeight(30);
+    layout->addWidget(createRequestButton);
+    
+    connect(createRequestButton, &QPushButton::clicked, this, &RequestsBox::createFriendRequest);
+}
+
+RequestsBox::~RequestsBox()
+{
+    // Qt will delete child widgets automatically
+}
+
+void RequestsBox::handlePacket(unsigned char *packet)
+{
+    switch (*packet) {
+        case PacketFromServerType::FRIEND_REQUEST_FORWARD: {
+            friendRequestForward forward(packet);
+            QString from = QString::fromStdString(forward.from);
+            addRequest(from, true); // Has buttons for Accept/Reject/Hide
+            break;
+        }
+        case PacketFromServerType::FRIEND_REQUEST_RESPONSE: {
+            friendRequestResponse response(packet);
+            QString from = QString::fromStdString(response.from);
+            removeRequest(from);
+            break;
+        }
+    }
+}
+
+void RequestsBox::addRequest(const QString &from, bool hasButtons)
+{
+    if (requestWidgets.contains(from)) {
+        return; // Already exists
+    }
+    
+    RequestBox *requestBox = new RequestBox(from, hasButtons, this);
+    requestWidgets[from] = requestBox;
+    layout->insertWidget(layout->count() - 1, requestBox); // Insert before the button
+    
+    connect(requestBox, &RequestBox::acceptRequest, this, [this](const QString &username) {
+        sendFriendRequestAcknowledge("", username, FriendRequestResponse::ACCEPT);
+        // Add friend to database
+        const char *sql = "INSERT INTO friends (friend_name, status) VALUES (?, ?)";
+        sqlite3_stmt *stmt;
+        int rc = sqlite3_prepare_v2(database, sql, -1, &stmt, nullptr);
+        if (rc == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, username.toUtf8().constData(), -1, SQLITE_STATIC);
+            sqlite3_bind_int(stmt, 2, FriendStatus::ONLINE);
+            sqlite3_step(stmt);
+            sqlite3_finalize(stmt);
+        }
+        removeRequest(username);
+    });
+    
+    connect(requestBox, &RequestBox::rejectRequest, this, [this](const QString &username) {
+        sendFriendRequestAcknowledge("", username, FriendRequestResponse::REJECT);
+        removeRequest(username);
+    });
+    
+    connect(requestBox, &RequestBox::hideRequest, this, [this](const QString &username) {
+        sendFriendRequestAcknowledge("", username, FriendRequestResponse::HIDE);
+        removeRequest(username);
+    });
+}
+
+void RequestsBox::removeRequest(const QString &from)
+{
+    if (requestWidgets.contains(from)) {
+        RequestBox *requestBox = requestWidgets[from];
+        layout->removeWidget(requestBox);
+        requestWidgets.remove(from);
+        delete requestBox;
+    }
+}
+
+void RequestsBox::sendFriendRequestAcknowledge(const QString &to, const QString &from, int response)
+{
+    friendRequestAcknowledge packet(to.toStdString(), from.toStdString(), static_cast<FriendRequestResponse>(response));
+    unsigned char buffer[PACKET_BUFFER_SIZE + 1];
+    buffer[PACKET_BUFFER_SIZE] = 0;
+    packet.write_to_packet(buffer);
+    
+    if (socket && socket->state() == QAbstractSocket::ConnectedState) {
+        socket->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
+    }
+}
+
+void RequestsBox::sendFriendRequestSend(const QString &target)
+{
+    friendRequestSend packet(target.toStdString());
+    unsigned char buffer[PACKET_BUFFER_SIZE + 1];
+    buffer[PACKET_BUFFER_SIZE] = 0;
+    packet.write_to_packet(buffer);
+    
+    if (socket && socket->state() == QAbstractSocket::ConnectedState) {
+        socket->write(reinterpret_cast<const char*>(buffer), PACKET_BUFFER_SIZE);
+    }
+}
+
+void RequestsBox::createFriendRequest()
+{
+    FriendRequestDialog dialog(this);
+    if (dialog.exec() == QDialog::Accepted) {
+        QString username = dialog.getUsername();
+        if (!username.isEmpty()) {
+            sendFriendRequestSend(username);
+        }
+    }
+}
+
+RequestBox::RequestBox(const QString &username, bool hasButtons, QWidget *parent)
+    : QWidget(parent), username(username)
+{
+    setFixedHeight(40);
+    setStyleSheet("QWidget { background-color: #f0f0f0; border: 1px solid #ccc; border-radius: 4px; }");
+    
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->setContentsMargins(10, 5, 10, 5);
+    
+    QLabel *nameLabel = new QLabel(username, this);
+    nameLabel->setStyleSheet("font-weight: bold; color: #333;");
+    layout->addWidget(nameLabel);
+    
+    layout->addStretch();
+    
+    if (hasButtons) {
+        // Create Accept, Reject, Hide buttons
+        acceptButton = new QPushButton("Accept", this);
+        acceptButton->setFixedSize(60, 25);
+        acceptButton->setStyleSheet("QPushButton { background-color: #4CAF50; color: white; border: none; border-radius: 3px; }");
+        layout->addWidget(acceptButton);
+        
+        rejectButton = new QPushButton("Reject", this);
+        rejectButton->setFixedSize(60, 25);
+        rejectButton->setStyleSheet("QPushButton { background-color: #f44336; color: white; border: none; border-radius: 3px; }");
+        layout->addWidget(rejectButton);
+        
+        hideButton = new QPushButton("Hide", this);
+        hideButton->setFixedSize(60, 25);
+        hideButton->setStyleSheet("QPushButton { background-color: #9E9E9E; color: white; border: none; border-radius: 3px; }");
+        layout->addWidget(hideButton);
+        
+        connect(acceptButton, &QPushButton::clicked, this, &RequestBox::onAcceptClicked);
+        connect(rejectButton, &QPushButton::clicked, this, &RequestBox::onRejectClicked);
+        connect(hideButton, &QPushButton::clicked, this, &RequestBox::onHideClicked);
+    } else {
+        // Show "Pending" label
+        statusLabel = new QLabel("Pending", this);
+        statusLabel->setStyleSheet("color: #FF9800; font-size: 10px; font-weight: bold;");
+        layout->addWidget(statusLabel);
+    }
+}
+
+void RequestBox::handlePacket(unsigned char *packet)
+{
+    // This method is not used for RequestBox, but kept for consistency
+    // Packet handling is done at the RequestsBox level
+}
+
+void RequestBox::onAcceptClicked()
+{
+    emit acceptRequest(username);
+}
+
+void RequestBox::onRejectClicked()
+{
+    emit rejectRequest(username);
+}
+
+void RequestBox::onHideClicked()
+{
+    emit hideRequest(username);
+}
+
+FriendRequestDialog::FriendRequestDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle("Create Friend Request");
+    setFixedSize(300, 120);
+    
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    
+    QLabel *label = new QLabel("Enter username:", this);
+    layout->addWidget(label);
+    
+    usernameEdit = new QLineEdit(this);
+    layout->addWidget(usernameEdit);
+    
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    QPushButton *sendButton = new QPushButton("Send", this);
+    QPushButton *cancelButton = new QPushButton("Cancel", this);
+    
+    buttonLayout->addWidget(sendButton);
+    buttonLayout->addWidget(cancelButton);
+    layout->addLayout(buttonLayout);
+    
+    connect(sendButton, &QPushButton::clicked, this, &FriendRequestDialog::onSendClicked);
+    connect(cancelButton, &QPushButton::clicked, this, &FriendRequestDialog::onCancelClicked);
+    
+    // Set focus to username edit
+    usernameEdit->setFocus();
+}
+
+QString FriendRequestDialog::getUsername() const
+{
+    return username;
+}
+
+void FriendRequestDialog::onSendClicked()
+{
+    username = usernameEdit->text().trimmed();
+    if (username.isEmpty()) {
+        QMessageBox::warning(this, "Error", "Please enter a username.");
+        return;
+    }
+    accept();
+}
+
+void FriendRequestDialog::onCancelClicked()
+{
+    reject();
+} 

--- a/src/app/requestsbox.cpp
+++ b/src/app/requestsbox.cpp
@@ -9,10 +9,9 @@
 #include <QDialogButtonBox>
 #include <QMessageBox>
 #include <QDebug>
-#include <QTcpSocket>
 
-RequestsBox::RequestsBox(sqlite3 *db, QTcpSocket *socket, QWidget *parent)
-    : QWidget(parent), database(db), socket(socket)
+RequestsBox::RequestsBox(QWidget *parent)
+    : QWidget(parent)
 {
     layout = new QVBoxLayout(this);
     layout->setSpacing(5);
@@ -36,27 +35,24 @@ void RequestsBox::processFriendRequest(QString name) {
 }
 
 void RequestsBox::processFriendResponse(QString name, FriendRequestResponse resp) {
-            QMessageBox msgBox;
-            switch (resp) {
-                case FriendRequestResponse::DOES_NOT_EXIST:
-                    msgBox.setText(QString::fromStdString("No user named '" + response.to + "'."));
-                    msgBox.exec();
-                break;
-                case FriendRequestResponse::DATABASE_ERROR:
-                    msgBox.setText("A database error occurred while trying to contact the user.");
-                    msgBox.exec();
-                break;
-                case FriendRequestResponse::PENDING:
-                qDebug() << "Adding request to " << response.to;
-                    addRequest(name, false);
-                break;
-                case FriendRequestResponse::ACCEPT:
-                    announceNewFriend(name);
-                case FriendRequestResponse::REJECT:
-                qDebug() << "Removing request from " << response.from << " to " << response.to;
-                    removeRequest(name);
-                    break;
-            }
+    QMessageBox msgBox;
+    switch (resp) {
+        case FriendRequestResponse::DOES_NOT_EXIST:
+            msgBox.setText(QString::fromStdString("No user with that name."));
+            msgBox.exec();
+        break;
+        case FriendRequestResponse::DATABASE_ERROR:
+            msgBox.setText("A database error occurred while trying to contact the user.");
+            msgBox.exec();
+        break;
+        case FriendRequestResponse::PENDING:
+            addRequest(name, false);
+        break;
+        case FriendRequestResponse::ACCEPT:
+            announceNewFriend(name);
+        case FriendRequestResponse::REJECT:
+            removeRequest(name);
+            break;
     }
 }
 
@@ -120,14 +116,15 @@ void RequestsBox::createFriendRequest()
         // sqlite3_finalize(stmt_chk);
 
         QMessageBox msgBox;
-        if (ans) {
-            msgBox.setText(QString::fromStdString("You are already friends with " + target_name + "."));
-            msgBox.exec();
-            return;
-        }
+        // if (ans) {
+        //     msgBox.setText("You are already friends with " + username);
+        //     msgBox.exec();
+        //     return;
+        // }
 
-        else if (requestWidgets.contains(username)) {
-            msgBox.setText(QString::fromStdString("You already have a request " + ( requestWidgets[username]->is_pending ? std::string("to ") : std::string("from ") ) + target_name + "."));
+        // else
+        if (requestWidgets.contains(username)) {
+            msgBox.setText(QString::fromStdString("You already have a request " + ( requestWidgets[username]->is_pending ? std::string("to ") : std::string("from ") )) + username + ".");
             msgBox.exec();
         }
         else {

--- a/src/app/requestsbox.cpp
+++ b/src/app/requestsbox.cpp
@@ -42,8 +42,24 @@ void RequestsBox::handlePacket(unsigned char *packet)
         }
         case PacketFromServerType::FRIEND_REQUEST_RESPONSE: {
             friendRequestResponse response(packet);
-            QString from = QString::fromStdString(response.from);
-            removeRequest(from);
+            QMessageBox msgBox;
+            switch (response.response) {
+                case FriendRequestResponse::DOES_NOT_EXIST:
+                    msgBox.setText(QString::fromStdString("No user named '" + response.to + "'."));
+                    msgBox.exec();
+                break;
+                case FriendRequestResponse::DATABASE_ERROR:
+                    msgBox.setText("A database error occurred while trying to contact the user.");
+                    msgBox.exec();
+                break;
+                case FriendRequestResponse::PENDING:
+                    addRequest(QString::fromStdString(response.to), false);
+                break;
+                case FriendRequestResponse::ACCEPT:
+                case FriendRequestResponse::REJECT:
+                    removeRequest(QString::fromStdString(response.to));
+                    break;
+            }
             break;
         }
     }

--- a/src/app/requestsbox.h
+++ b/src/app/requestsbox.h
@@ -25,13 +25,16 @@ public:
 
     void handlePacket(unsigned char *packet);
     QString my_name;
+public signals:
+    requestFriendRequest(QString name);
+    requestFriendResponse(QString name, FriendRequestResponse resp);
+    announceNewFriend(QString name);
 
 private slots:
-    void createFriendRequest();
+    processFriendRequest(QString name);
+    processFriendResponse(QString name, FriendRequestResponse resp);
 
 private:
-    sqlite3 *database;
-    QTcpSocket *socket;
     QVBoxLayout *layout;
     QMap<QString, RequestBox*> requestWidgets;
     

--- a/src/app/requestsbox.h
+++ b/src/app/requestsbox.h
@@ -10,7 +10,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QString>
-#include <sqlite3.h>
+#include "packet.h"
 
 class RequestBox;
 class QTcpSocket;
@@ -20,19 +20,19 @@ class RequestsBox : public QWidget
     Q_OBJECT
 
 public:
-    explicit RequestsBox(sqlite3 *db, QTcpSocket *socket, QWidget *parent = nullptr);
+    explicit RequestsBox(QWidget *parent = nullptr);
     ~RequestsBox();
 
     void handlePacket(unsigned char *packet);
     QString my_name;
-public signals:
-    requestFriendRequest(QString name);
-    requestFriendResponse(QString name, FriendRequestResponse resp);
-    announceNewFriend(QString name);
+signals:
+    void requestFriendRequest(QString name);
+    void requestFriendResponse(QString name, FriendRequestResponse resp);
+    void announceNewFriend(QString name);
 
-private slots:
-    processFriendRequest(QString name);
-    processFriendResponse(QString name, FriendRequestResponse resp);
+public slots:
+    void processFriendRequest(QString name);
+    void processFriendResponse(QString name, FriendRequestResponse resp);
 
 private:
     QVBoxLayout *layout;
@@ -42,6 +42,9 @@ private:
     void removeRequest(const QString &from);
     void sendFriendRequestAcknowledge(const QString &to, const QString &from, int response);
     void sendFriendRequestSend(const QString &target);
+
+private slots:
+    void createFriendRequest();
 };
 
 class RequestBox : public QWidget

--- a/src/app/requestsbox.h
+++ b/src/app/requestsbox.h
@@ -9,6 +9,7 @@
 #include <QLineEdit>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QString>
 #include <sqlite3.h>
 
 class RequestBox;
@@ -23,6 +24,7 @@ public:
     ~RequestsBox();
 
     void handlePacket(unsigned char *packet);
+    QString my_name;
 
 private slots:
     void createFriendRequest();

--- a/src/app/requestsbox.h
+++ b/src/app/requestsbox.h
@@ -48,6 +48,7 @@ class RequestBox : public QWidget
 public:
     explicit RequestBox(const QString &username, bool hasButtons, QWidget *parent = nullptr);
     void handlePacket(unsigned char *packet);
+    bool is_pending;
 
 signals:
     void acceptRequest(const QString &username);

--- a/src/app/requestsbox.h
+++ b/src/app/requestsbox.h
@@ -1,0 +1,85 @@
+#ifndef REQUESTSBOX_H
+#define REQUESTSBOX_H
+
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QMap>
+#include <QPushButton>
+#include <QDialog>
+#include <QLineEdit>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <sqlite3.h>
+
+class RequestBox;
+class QTcpSocket;
+
+class RequestsBox : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit RequestsBox(sqlite3 *db, QTcpSocket *socket, QWidget *parent = nullptr);
+    ~RequestsBox();
+
+    void handlePacket(unsigned char *packet);
+
+private slots:
+    void createFriendRequest();
+
+private:
+    sqlite3 *database;
+    QTcpSocket *socket;
+    QVBoxLayout *layout;
+    QMap<QString, RequestBox*> requestWidgets;
+    
+    void addRequest(const QString &from, bool hasButtons);
+    void removeRequest(const QString &from);
+    void sendFriendRequestAcknowledge(const QString &to, const QString &from, int response);
+    void sendFriendRequestSend(const QString &target);
+};
+
+class RequestBox : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit RequestBox(const QString &username, bool hasButtons, QWidget *parent = nullptr);
+    void handlePacket(unsigned char *packet);
+
+signals:
+    void acceptRequest(const QString &username);
+    void rejectRequest(const QString &username);
+    void hideRequest(const QString &username);
+
+private slots:
+    void onAcceptClicked();
+    void onRejectClicked();
+    void onHideClicked();
+
+private:
+    QString username;
+    QLabel *statusLabel;
+    QPushButton *acceptButton;
+    QPushButton *rejectButton;
+    QPushButton *hideButton;
+};
+
+class FriendRequestDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit FriendRequestDialog(QWidget *parent = nullptr);
+    QString getUsername() const;
+
+private slots:
+    void onSendClicked();
+    void onCancelClicked();
+
+private:
+    QLineEdit *usernameEdit;
+    QString username;
+};
+
+#endif // REQUESTSBOX_H 

--- a/src/server/packet.cpp
+++ b/src/server/packet.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cstdint>
 #include <string>
 #include <stdexcept>
 #include "packet.h"
@@ -122,7 +124,7 @@ messageSend::messageSend(unsigned char * buffer) {
     
     bytes_remaining = *(uint32_t *)(buffer + 4);
     recipient = std::string((char *)buffer + 8);
-    uint32_t readable = min(PACKET_BUFFER_SIZE - 9 - recipient.size(), bytes_remaining);
+    uint32_t readable = std::min((uint32_t)(PACKET_BUFFER_SIZE - 9 - recipient.size()), bytes_remaining);
     message = std::string((char *)buffer + 9 + recipient.size(), readable);
     bytes_remaining -= readable;
 }
@@ -141,7 +143,7 @@ int messageSend::write_to_packet(unsigned char * buffer) {
 
     if (writeable > message.size()) writeable = message.size();
     message.substr(message.size() - bytes_remaining, writeable).copy((char *)buffer + 9, writeable);
-    bytes_remaining -= writeable
+    bytes_remaining -= writeable;
     
     return bytes_remaining;
 }
@@ -149,7 +151,7 @@ int messageSend::write_to_packet(unsigned char * buffer) {
 int messageSend::read_from_packet(unsigned char * buffer) {
     if (*buffer != type) throw std::runtime_error("Attempting to read message send from wrong sort of packet");
     if (bytes_remaining != *(uint32_t *)(buffer + 4)) throw std::runtime_error("Packet length inconsistent");
-    uint32_t readable = min(PACKET_BUFFER_SIZE - 8, bytes_remaining);
+    uint32_t readable = std::min((uint32_t)(PACKET_BUFFER_SIZE - 8), bytes_remaining);
     message += std::string((char *)buffer + 8, readable);
     bytes_remaining -= readable;
 
@@ -304,8 +306,8 @@ messageForward::messageForward(unsigned char * buffer) {
     
     bytes_remaining = *(uint32_t *)(buffer + 4);
     sender = std::string((char *)buffer + 8);
-    uint32_t readable = min(PACKET_BUFFER_SIZE - 9 - recipient.size(), bytes_remaining);
-    message = std::string((char *)buffer + 9 + recipient.size(), readable);
+    uint32_t readable = std::min((uint32_t)(PACKET_BUFFER_SIZE - 9 - sender.size()), bytes_remaining);
+    message = std::string((char *)buffer + 9 + sender.size(), readable);
     bytes_remaining -= readable;
 }
 
@@ -315,8 +317,8 @@ int messageForward::write_to_packet(unsigned char * buffer) {
 
     uint32_t writeable;
     if (bytes_remaining == message.size()) {
-        sender.copy((char *)buffer + 8; sender.size());
-        *(buffer + 8 + sender.size()) == 0;
+        sender.copy((char *)buffer + 8, sender.size());
+        *(buffer + 8 + sender.size()) = 0;
         writeable = PACKET_BUFFER_SIZE - 9 - sender.size();
     }
     else writeable = PACKET_BUFFER_SIZE - 8;
@@ -331,7 +333,7 @@ int messageForward::write_to_packet(unsigned char * buffer) {
 int messageForward::read_from_packet(unsigned char * buffer) {
     if (*buffer  != type) throw std::runtime_error("Attempting to read message forward from wrong type of packet");
     if (bytes_remaining != *(uint32_t *)(buffer + 4)) throw std::runtime_error("Packet length inconsistent");
-    uint32_t readable = min(PACKET_BUFFER_SIZE - 8, bytes_remaining);
+    uint32_t readable = std::min((uint32_t)(PACKET_BUFFER_SIZE - 8), bytes_remaining);
     message += std::string((char *)buffer + 8, readable);
     bytes_remaining -= readable;
 

--- a/src/server/packet.h
+++ b/src/server/packet.h
@@ -97,6 +97,8 @@ class messageSend : public packetToServer {
     int write_to_packet(unsigned char * buffer);
     std::string message;
     std::string recipient;
+    uint32_t bytes_remaining;
+    int read_from_packet(unsigned char * buffer);
 };
 
 // PacketFromServer derivatives
@@ -153,6 +155,8 @@ class messageForward : public packetFromServer {
     int write_to_packet(unsigned char * buffer);
     std::string message;
     std::string sender;
+    uint32_t bytes_remaining;
+    int read_from_packet(unsigned char * buffer);
 };
 
 class messageResponse : public packetFromServer {

--- a/src/server/packet.h
+++ b/src/server/packet.h
@@ -49,8 +49,8 @@ class packetFromServer {
     public:
     virtual int write_to_packet(unsigned char * buffer) { return 0; }
     ~packetFromServer() { }
-    protected:
     PacketFromServerType type;
+    protected:
 };
 
 // PacketToServer derivatives

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -313,6 +313,7 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                                     sqlite3_free(zErrMsg);
                                 }
                                 for (auto &name : names) {
+                                    std::cout << "Checking status of: " << name << std::endl;
                                     std::unique_lock<std::mutex> lock(clientMutex);
                                     // bool has_name = clientIPs.contains(name);
                                     bool has_name = (clientIPs.find(name) != clientIPs.end());
@@ -322,6 +323,10 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                                         sendOutPacket(connectedUser, fsu);
                                         fsu = std::make_shared<friendStatusUpdate>(connectedUser, FriendStatus::ONLINE);
                                         sendOutPacket(name, fsu);
+                                    }
+                                    else {
+                                        fsu = std::make_shared<friendStatusUpdate>(name, FriendStatus::ONLINE);
+                                        sendOutPacket(connectedUser, fsu);
                                     }
                                 }
                             }
@@ -380,11 +385,12 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                     case FriendRequestResponse::ACCEPT:
                     db_statement = "INSERT INTO friends (left, right) VALUES ('" + connectedUser + "', '" + fra->from + "'); "
                                 + "INSERT INTO friends (left, right) VALUES ('" + fra->from + "', '" + connectedUser + "')";
-                    std::cout << "It's an accepted request - should be running the query: " << db_statement;
+                    std::cout << "It's an accepted request - should be running the query: " << db_statement << ";\n";
                     if (sqlite3_exec(db, db_statement.c_str(), NULL, NULL, &zErrMsg) != SQLITE_OK) { 
                         std::cout << "Error in SQLite: " << std::string(zErrMsg) << std::endl;
                         sqlite3_free(zErrMsg);
                     }
+                    resp = new friendRequestResponse(fra->from, connectedUser, fra->response);
                     case FriendRequestResponse::REJECT:
                     frr = std::make_shared<friendRequestResponse>(connectedUser, fra->from, fra->response);
                         std::cout << "Passing on that information to " << fra->to;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -436,6 +436,10 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                 std::cout << "Received a message send packet ";
                 req = new messageSend(receiveBuffer);
                 ms = dynamic_cast<messageSend *>(req);
+                if (ms->bytes_remaining) {
+                    recv(clientSocket, (char *)receiveBuffer, sizeof(receiveBuffer) - 1, 0);
+                    while ms->read_from_packet(receiveBuffer) recv(clientSocket, (char *)receiveBuffer, sizeof(receiveBuffer) - 1, 0)
+                }
                 std::cout << "with message: '" << ms->message << "' to recipient: '" << ms->recipient << "'.\n";
                 
                 // Check if the recipient is online (in clientIPs)

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -325,7 +325,7 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                 std::cout << "Received a friend request send packet ";
                 req = new friendRequestSend(receiveBuffer);
                 frs = dynamic_cast<friendRequestSend *>(req);
-                std::cout << "targeting user: '" << frs->target_name << "'.\n";
+                std::cout << "from user " << connectedUser << " targeting user: '" << frs->target_name << "'.\n";
                 
                 // Check if the target username exists in users table
                 db_statement = "SELECT COUNT(*) FROM users WHERE user_name = '" + frs->target_name + "';";
@@ -340,7 +340,7 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                     }
                     else {
                         // Target user exists, insert the request into the requests database
-                        db_statement = "INSERT INTO requests (to, from) VALUES ('" + frs->target_name + "', '" + connectedUser + "');";
+                        db_statement = "INSERT INTO requests (recipient, sender) VALUES ('" + frs->target_name + "', '" + connectedUser + "');";
                         if (sqlite3_exec(db, db_statement.c_str(), NULL, NULL, &zErrMsg) != SQLITE_OK) {
                             std::cout << "Error in SQLite: " << std::string(zErrMsg) << std::endl;
                             sqlite3_free(zErrMsg);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -336,6 +336,7 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                 }
                 else {
                     if (targetExists == 0) {
+                        std::cout << "That target does not exist.\n";
                         resp = new friendRequestResponse(frs->target_name, connectedUser, FriendRequestResponse::DOES_NOT_EXIST);
                     }
                     else {
@@ -461,7 +462,10 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
 void MillenniumServer::sendOutPacket(std::string to, std::shared_ptr<packetFromServer> f) {
     std::cout << "Sending a packet to " << to << std::endl;
     std::unique_lock infoLock(clientMutex);
-    if (clientIPs.find(to) == clientIPs.end()) return;
+    if (clientIPs.find(to) == clientIPs.end()) {
+        std::cout << "That user is not online.\n";
+        return;
+    }
     std::string destIPStr = clientIPs[to];
     std::unique_lock socketLock(*(socketMutexes[destIPStr]));
     SOCKET destSocket = clientSockets[destIPStr];

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -460,17 +460,31 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
         // std::string response = "Server received: " + std::string((char *)receiveBuffer);
 
         if (resp) {
-            std::cout << "All good, about to send packet\n";
+            std::cout << "To the connected user, sending a packet of type ";
             std::lock_guard<std::mutex> myLock(*(socketMutexes[clientIP]));
 
-            // while (resp->write_to_packet(sendBuffer)) {
-            //     int sbyteCount = send(clientSocket, (char *)sendBuffer, PACKET_BUFFER_SIZE, 0);
-            //     if (sbyteCount == SOCKET_ERROR) {
-            //         std::cout << "Error sending to client " << clientIP << ": " << WSAGetLastError() << std::endl;
-            //         delete resp;
-            //         goto close;
-            //     }
-            // }
+            switch (resp->type) {
+                case (PacketFromServerType::ACCOUNT_RESULT):
+                    std::cout << "account result"; break;
+                case (PacketFromServerType::LOGIN_RESULT):
+                    std::cout << "login result"; break;
+                case (PacketFromServerType::FRIEND_STATUS_UPDATE):
+                    std::cout << "friend status update"; break;
+                case (PacketFromServerType::FRIEND_REQUEST_FORWARD):
+                    std::cout << "friend request forward"; break;
+                case (PacketFromServerType::FRIEND_REQUEST_RESPONSE):
+                    std::cout << "friend request response"; break;
+                case (PacketFromServerType::MESSAGE_FORWARD):
+                    std::cout << "message forward"; break;
+                case (PacketFromServerType::MESSAGE_RESPONSE):
+                    std::cout << "message response"; break;
+                default:
+                    std::cout << "invalid";
+            }
+
+            std::cout << "\n";
+
+
             resp->write_to_packet(sendBuffer); // all response packets are short
             int sbyteCount = send(clientSocket, (char *)sendBuffer, PACKET_BUFFER_SIZE, 0);
             if (sbyteCount == SOCKET_ERROR) {

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -438,7 +438,7 @@ void MillenniumServer::handleClient(SOCKET clientSocket, std::string clientIP) {
                 ms = dynamic_cast<messageSend *>(req);
                 if (ms->bytes_remaining) {
                     recv(clientSocket, (char *)receiveBuffer, sizeof(receiveBuffer) - 1, 0);
-                    while ms->read_from_packet(receiveBuffer) recv(clientSocket, (char *)receiveBuffer, sizeof(receiveBuffer) - 1, 0)
+                    while (ms->read_from_packet(receiveBuffer)) recv(clientSocket, (char *)receiveBuffer, sizeof(receiveBuffer) - 1, 0);
                 }
                 std::cout << "with message: '" << ms->message << "' to recipient: '" << ms->recipient << "'.\n";
                 


### PR DESCRIPTION
Move everything relating to the socket to its own QObject and move everything relating to the database to its own QObject.  This makes the code easier to follow, and causes graceful disconnection from the server.