### PR TITLE
Local database by username

### DIFF
--- a/src/app/clientsocket.cpp
+++ b/src/app/clientsocket.cpp
@@ -136,15 +136,13 @@ void ClientSocketManager::handlePacket(char *packet)
     switch (packetType) {
         case ACCOUNT_RESULT: {
             createAccountResponse response(reinterpret_cast<unsigned char*>(packet));
-            if (response.success) emit mentionLoginSuccess();
-            else emit mentionAccountResult(QString::fromStdString(response.reason));
+            emit mentionAccountResult(response.success, QString::fromStdString(response.reason));
             break;
         }
         
         case LOGIN_RESULT: {
             loginResult response(reinterpret_cast<unsigned char*>(packet));
-            if (response.success) emit mentionLoginSuccess();
-            else emit mentionLoginResult(QString::fromStdString(response.reason));
+            emit mentionLoginResult(response.success, QString::fromStdString(response.reason));
             break;
         }
         

--- a/src/app/clientsocket.h
+++ b/src/app/clientsocket.h
@@ -14,9 +14,8 @@ public:
     ~ClientSocketManager();
     
 signals:
-    void mentionAccountResult(QString reason);
-    void mentionLoginResult(QString reason);
-    void mentionLoginSuccess();
+    void mentionAccountResult(bool result, QString reason);
+    void mentionLoginResult(bool result, QString reason);
     void mentionFriendStatus(QString friend_name, FriendStatus status);
     void mentionFriendRequest(QString friend_name);
     void mentionFriendResponse(QString friend_name, FriendRequestResponse response);

--- a/src/app/database.cpp
+++ b/src/app/database.cpp
@@ -283,3 +283,8 @@ void ClientDatabaseManager::queryMessages(QString friend_name, int count, int be
     
     emit outputMessageQuery(messages, firstMessageId);
 }
+
+void ClientDatabaseManager::onLogin(QString username) {
+    logged_in_user = username;
+    queryFriends();
+}

--- a/src/app/database.h
+++ b/src/app/database.h
@@ -39,6 +39,9 @@ signals:
     void reportOutgoingMessage(QString message, QString recipient);
     void reportNewFriend(int id, QString name, int status);
 
+public slots:
+    void onLogin(QString username);
+
 private:
     sqlite3 * database;
     QString queried_friend = "";

--- a/src/app/login.cpp
+++ b/src/app/login.cpp
@@ -62,7 +62,8 @@ void LoginWidget::login() {
     else emit requestLogin(usernameEdit->text(), passwordEdit->text());
 }
 
-void LoginWidget::handleFailure(QString reason) {
-    if (creating_account) message->setText("Failed to create account: " + reason);
+void LoginWidget::handleLoginResult(bool result, QString reason) {
+    if (result) reportLoginSuccess(usernameEdit->text()); // should this be stored on login attempt in case user types before login result?
+    else if (creating_account) message->setText("Failed to create account: " + reason);
     else message->setText("Failed to log in: " + reason);
 }

--- a/src/app/login.h
+++ b/src/app/login.h
@@ -17,8 +17,9 @@ public:
 signals:
     void requestAccount(QString username, QString password);
     void requestLogin(QString username, QString password);
+    void reportLoginSuccess(QString username);
 public slots:
-    void handleFailure(QString reason);
+    void handleLoginResult(bool result, QString reason);
 private slots:
     void swapLoginPurpose();
     void login();

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -27,7 +27,7 @@ public:
     explicit MainWindow(QString server_address, QWidget *parent = nullptr);
     ~MainWindow();
 
-    void showMainCentralWidget();
+    void showMainCentralWidget(QString username);
     void showLoginWidget();
     void showError(QString message);
 


### PR DESCRIPTION
Adds a column to the client's friend database, giving each friend a unique ID based on name and currently logged in user, and using that for all queries.  In preliminary testing, it appears to have fixed issues regarding logging in as multiple accounts.

Intended to resolve #23 