### PR TITLE
Add video demonstration link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ and for the client of one sending messages to a central server.  Its code is fou
 * **MillenniumFalcon** is the server itself, and the first program to be named,
 originating the animal theme.  Its code is found in `src/server`.
 
+A video demonstration of the software is available on [YouTube](https://youtu.be/F3YZL87vvvQ).
+
 ### Libraries
 * `millennium_crypt` contains functions and classes for implementing the special code, managing codebooks, etc.
 Its code is found in `src/crypt`.


### PR DESCRIPTION
Added a link to a video demonstration of the software.  This video demonstration is the result of testing to address issues #14 and #15 , both of which are to be considered resolved now.

Resolves #14 
Resolves #15 